### PR TITLE
perf(map): Cap Max Sprite Textures at 16

### DIFF
--- a/src/components/WorksiteMap.vue
+++ b/src/components/WorksiteMap.vue
@@ -85,7 +85,14 @@
 </style>
 
 <script>
-import { Container, Loader, Sprite, Texture } from 'pixi.js';
+import {
+  Container,
+  Loader,
+  Sprite,
+  Texture,
+  settings as PixiSettings,
+} from 'pixi.js';
+
 import * as L from 'leaflet';
 import 'leaflet-loading';
 import 'leaflet.gridlayer.googlemutant';
@@ -98,6 +105,11 @@ import { averageGeolocation } from '@/utils/map';
 import { colors, templates } from '@/icons/icons_templates';
 import { groupBy } from '@/utils/array';
 import Worksite from '@/models/Worksite';
+
+PixiSettings.SPRITE_MAX_TEXTURES = Math.min(
+  PixiSettings.SPRITE_MAX_TEXTURES,
+  16,
+);
 
 L.Icon.Default.imagePath = '.';
 // OR


### PR DESCRIPTION
**Changes**

* Reduce [PIXI.SPRITE_MAX_TEXTURES](https://pixijs.download/dev/docs/PIXI.settings.html#.SPRITE_MAX_TEXTURES) to 16.

After trying to load an incident in Firefox Developer Edition in an environment with Mesa graphics drivers I was met with the following error:

`Pixi.js Warning: gl.getProgramInfoLog() Programs with more than 16 samplers are disallowed on Mesa drivers to avoid crashing.`

Which essentially prevented the map from loading. After doing some research and coming across pixijs/pixi.js#4478 I gave reducing `SPRITE_MAX_TEXTURES` and not only did it fix the FF-dev issue, but also seems to have provided an overall performance boost in all browsers **without any visual change that I am aware of.**

In a chrome environment I ran some profiling and here's what I found:

At the default `PIXI.SPRITE_MAX_TEXTURES` value of 32:
![chromeprev](https://user-images.githubusercontent.com/5913808/71712039-30492d80-2dc9-11ea-9fed-d895455717c6.gif)

The very top bar with (with the green and red graphs) indicate FPS, with red indicative of frame drops that would be considered a poor user experience. As you can see, on each re-render of the sprites, the user experiences a sharp decrease in frames followed by **rapid stuttering as the sprites resize.**

Now compared to `PIXI.SPRITE_MAX_TEXTURES` at 16:
![chromepost](https://user-images.githubusercontent.com/5913808/71712248-0e9c7600-2dca-11ea-84c8-9d5d2c34a584.gif)

Here two obvious changes stand out, 

1.) The initial frame drop is reduced on average by **100ms**
2.) The frames recover despite the sprites continuing to resize. (No more stuttering)

This among other factors such as reduced memory/other resource consumption as well. 

If you want to play around with this, here are the two chrome profiles:
[profiles.zip](https://github.com/CrisisCleanup/crisiscleanup-3-web/files/4018437/profiles.zip)

