### PR TITLE
Refactor Worksite Map

### DIFF
--- a/icon_templates/circle.hbs
+++ b/icon_templates/circle.hbs
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" height="18" width="18">
-    <circle cx="9" cy="9" r="9" stroke="white" stroke-width="1.5" fill="{{fillColor}}" />
+  <circle cx="9" cy="9" r="9" stroke="#ffffff" stroke-width="1" fill="{{fillColor}}" />
 </svg>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10867,9 +10867,9 @@
       }
     },
     "leaflet": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.5.1.tgz",
-      "integrity": "sha512-ekM9KAeG99tYisNBg0IzEywAlp0hYI5XRipsqRXyRTeuU8jcuntilpp+eFf5gaE0xubc9RuSNIVtByEKwqFV0w=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.6.0.tgz",
+      "integrity": "sha512-CPkhyqWUKZKFJ6K8umN5/D2wrJ2+/8UIpXppY7QDnUZW5bZL5+SEI2J7GBpwh4LIupOKqbNSQXgqmrEJopHVNQ=="
     },
     "leaflet-loading": {
       "version": "0.1.24",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "exports-loader": "^0.7.0",
     "google-maps-api-loader": "^1.1.1",
     "handlebars": "^4.5.3",
-    "leaflet": "^1.3.1",
+    "leaflet": "^1.6.0",
     "leaflet-loading": "^0.1.24",
     "leaflet-pixi-overlay": "^1.8.1",
     "leaflet.gridlayer.googlemutant": "^0.6.4",

--- a/public/circle.svg
+++ b/public/circle.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="18" width="18">
+    <circle cx="9" cy="9" r="9" stroke="#ffffff" stroke-width="1" fill="#ffffff" />
+</svg>

--- a/src/components/WorksiteMap.vue
+++ b/src/components/WorksiteMap.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="fullsize-map" style="position: relative;">
+  <div id="map" ref="map" style="height: 100%; width: 100%;" class="relative">
     <div
       v-if="mapLoading"
       style="z-index: 1001;"
@@ -74,15 +74,8 @@
         </div>
       </div>
     </div>
-    <div ref="map" class="home-map"></div>
   </div>
 </template>
-<style>
-.fullsize-map {
-  height: 100vh;
-  width: 100%;
-}
-</style>
 
 <script>
 import {
@@ -151,37 +144,9 @@ export default {
   props: {
     query: Object,
     currentFilters: Object,
-    newMarker: Object,
   },
   data() {
     return {
-      ready: false,
-      points: [],
-      autoplay: true,
-      mapTimers: [],
-      // tileLayer: L.tileLayer('https://api.pitneybowes.com/location-intelligence/geomap/v1/tile/osm/{z}/{x}/{y}.png?api_key={api_key}', {
-      //     api_key: process.env.VUE_APP_PITNEYBOWES_API_KEY,
-      //     maxZoom: 18,
-      //     attribution: '<a class="leaflet-attribution" target="_blank" href="http://www.openstreetmap.org/copyright">&copy; OpenStreetMap contributors</a>',
-      // }),
-      tileLayer: L.tileLayer(
-        'https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png',
-        {
-          attribution:
-            '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>',
-          detectRetina: false,
-          maxZoom: 18,
-          noWrap: false,
-        },
-      ),
-      mapLoading: false,
-      markerLayer: L.layerGroup(),
-      markers: [],
-      showInteractivePopover: false,
-      loader: new Loader(),
-      colors,
-      templates,
-      pixiContainer: new Container(),
       displayedWorkTypes: {},
       displayedWorkTypeSvgs: [],
       legendColors: {
@@ -203,6 +168,11 @@ export default {
         [this.$t('Out of scope')]: colors['closed_out-of-scope_unclaimed']
           .fillColor,
       },
+      mapLoading: false,
+      markerLayer: L.layerGroup(),
+      markers: [],
+      markerSprites: [],
+      showInteractivePopover: false,
     };
   },
   computed: {
@@ -211,13 +181,10 @@ export default {
     },
   },
   watch: {
-    newMarker() {
-      this.addWorksite(this.newMarker);
-    },
     displayedWorkTypes: {
       handler(val) {
         this.displayedWorkTypeSvgs = Object.keys(val).map(workType => {
-          const template = this.templates[workType] || this.templates.unknown;
+          const template = templates[workType] || templates.unknown;
           const svg = template
             .replace('{{fillColor}}', 'black')
             .replace('{{strokeColor}}', 'black')
@@ -231,56 +198,329 @@ export default {
       deep: true,
     },
   },
-  mounted() {
-    const options = {
-      center: L.latLng(39, -90),
-      zoom: 4,
-      loadingControl: true,
-      preferCanvas: true,
-    };
-    this.initMap(options);
-    this.ready = true;
-  },
-  beforeDestroy() {
-    this.map.off();
-    this.map.remove();
+  async mounted() {
+    if (!this.query.incident) {
+      return;
+    }
+    this.mapLoading = true;
+    const response = await this.$http.get(
+      `${process.env.VUE_APP_API_BASE_URL}/worksites_all`,
+      {
+        params: { ...this.query },
+      },
+    );
+
+    this.markers = response.data.results;
+    await this.loadMap(response.data.results);
+
+    this.$nextTick(() => {
+      // Add this slight pan to re-render map
+      this.map.panBy([1, 0]);
+    });
+    this.mapLoading = false;
   },
   methods: {
-    async initMap(options) {
-      if (this.map) {
-        this.map.off();
-        this.map.remove();
-        this.map = null;
-      }
+    async loadMap(markers) {
+      await new Promise(resolve => {
+        const self = this;
+        const loader = new Loader();
+        loader.add('circle', '/circle.svg');
+        loader.load(() => {
+          this.map = L.map('map').setView([31.0, -100.0], 12);
+          const { map } = this;
+          if (this.currentUser.states && this.currentUser.states.mapViewPort) {
+            const {
+              _northEast,
+              _southWest,
+            } = this.currentUser.states.mapViewPort;
+            this.map.fitBounds([
+              [_northEast.lat, _northEast.lng],
+              [_southWest.lat, _southWest.lng],
+            ]);
+          }
+          this.markerLayer.addTo(this.map);
 
-      this.map = L.map(this.$refs.map, options);
-      this.$emit('initMap', this.map);
-      this.map.on('moveend', () => {
-        this.$emit('mapMoved', this.map.getBounds());
-        this.showInteractivePopover = false;
+          L.tileLayer(
+            'https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png',
+            {
+              attribution:
+                '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>',
+              detectRetina: false,
+              maxZoom: 18,
+              noWrap: false,
+            },
+          ).addTo(map);
+          map.attributionControl.setPosition('bottomright');
+          const pixiLayer = (function() {
+            let firstDraw = true;
+            let prevZoom;
+            let prevCenter;
+            const markerSprites = [];
+            let frame = null;
+            const pixiContainer = new Container();
+            self.pixiContainer = pixiContainer;
+            const doubleBuffering =
+              /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
+            return L.pixiOverlay(
+              function(utils) {
+                const zoom = utils.getMap().getZoom();
+                const center = utils.getMap().getCenter();
+                if (frame) {
+                  cancelAnimationFrame(frame);
+                  frame = null;
+                }
+                const container = utils.getContainer();
+                const renderer = utils.getRenderer();
+                const project = utils.latLngToLayerPoint;
+                const scale = utils.getScale();
+                const invScale = 0.75 / scale;
+                if (firstDraw) {
+                  prevZoom = zoom;
+                  prevCenter = center;
+                  markers.forEach(function(marker) {
+                    const coords = project([
+                      marker.location.coordinates[1],
+                      marker.location.coordinates[0],
+                    ]);
+
+                    const markerSprite = new Sprite();
+                    const work_type = Worksite.getWorkType(
+                      marker.work_types,
+                      self.currentFilters,
+                      self.currentUser.organization,
+                    );
+
+                    self.displayedWorkTypes[work_type.work_type] = true;
+                    self.displayedWorkTypes = { ...self.displayedWorkTypes };
+
+                    const colorsKey = `${work_type.status}_${
+                      work_type.claimed_by ? 'claimed' : 'unclaimed'
+                    }`;
+                    const worksiteTemplate = templates.circle;
+                    const spriteColors = colors[colorsKey];
+
+                    if (spriteColors) {
+                      const svg = worksiteTemplate
+                        .replace('{{fillColor}}', spriteColors.fillColor)
+                        .replace('{{strokeColor}}', spriteColors.strokeColor)
+                        .replace(
+                          '{{multple}}',
+                          marker.work_types.length > 1 ? templates.plus : '',
+                        );
+                      markerSprite.texture = Texture.from(svg);
+                    }
+                    markerSprite.x = coords.x;
+                    markerSprite.y = coords.y;
+                    markerSprite.x0 = coords.x;
+                    markerSprite.y0 = coords.y;
+                    markerSprite.anchor.set(0.5, 0.5);
+                    // markerSprite.alpha = getOpacity(marker.updated_at);
+                    container.addChild(markerSprite);
+                    markerSprites.push(markerSprite);
+                    markerSprite.legend = marker.city || marker.label;
+                    markerSprite.location = marker.location;
+                    markerSprite.work_types = marker.work_types;
+                    markerSprite.active_work_type = work_type;
+                    markerSprite.colorsKey = colorsKey;
+                    markerSprite.id = marker.id;
+                    markerSprite.alpha = getOpacity(marker.updated_at);
+                  });
+
+                  const quadTrees = {};
+                  for (
+                    let z = INTERACTIVE_ZOOM_LEVEL;
+                    z <= map.getMaxZoom();
+                    z++
+                  ) {
+                    const rInit = (z <= 7 ? 16 : 24) / utils.getScale(z);
+                    quadTrees[z] = solveCollision(markerSprites, {
+                      r0: rInit,
+                      zoom: z,
+                    });
+                  }
+                  const findMarker = ll => {
+                    if (utils.getMap().getZoom() < INTERACTIVE_ZOOM_LEVEL) {
+                      return null;
+                    }
+                    const layerPoint = project(ll);
+                    const quadTree = quadTrees[utils.getMap().getZoom()];
+                    let marker;
+                    const { rMax } = quadTree;
+                    let found = false;
+                    quadTree.visit(function(quad, x1, y1, x2, y2) {
+                      if (!quad.length) {
+                        const dx = quad.data.x - layerPoint.x;
+                        const dy = quad.data.y - layerPoint.y;
+                        const r = quad.data.scale.x * 16;
+                        if (dx * dx + dy * dy <= r * r) {
+                          marker = quad.data;
+                          found = true;
+                        }
+                      }
+                      return (
+                        found ||
+                        x1 > layerPoint.x + rMax ||
+                        x2 + rMax < layerPoint.x ||
+                        y1 > layerPoint.y + rMax ||
+                        y2 + rMax < layerPoint.y
+                      );
+                    });
+                    return marker;
+                  };
+
+                  map.on('click', function(e) {
+                    const marker = findMarker(e.latlng);
+                    if (marker) {
+                      self.$emit('onSelectmarker', marker);
+                    } else {
+                      map.closePopup();
+                    }
+
+                    if (utils.getMap().getZoom() < INTERACTIVE_ZOOM_LEVEL) {
+                      self.showInteractivePopover = true;
+                    }
+                  });
+
+                  map.on(
+                    'mousemove',
+                    L.Util.throttle(e => {
+                      const marker = findMarker(e.latlng);
+                      if (marker) {
+                        L.DomUtil.addClass(this._container, 'cursor-pointer');
+                      } else {
+                        L.DomUtil.removeClass(
+                          this._container,
+                          'cursor-pointer',
+                        );
+                      }
+                    }, 32),
+                  );
+                }
+                if (firstDraw || prevZoom !== zoom || prevCenter !== center) {
+                  self.$emit('mapMoved', map.getBounds());
+                  markerSprites.forEach(function(markerSprite) {
+                    if (zoom >= INTERACTIVE_ZOOM_LEVEL) {
+                      if (
+                        utils
+                          .getMap()
+                          .getBounds()
+                          .contains([
+                            markerSprite.location.coordinates[1],
+                            markerSprite.location.coordinates[0],
+                          ])
+                      ) {
+                        const work_type = Worksite.getWorkType(
+                          markerSprite.work_types,
+                          self.currentFilters,
+                          self.currentUser.organization,
+                        );
+
+                        const colorsKey = `${work_type.status}_${
+                          work_type.claimed_by ? 'claimed' : 'unclaimed'
+                        }`;
+
+                        const spriteColors = colors[colorsKey];
+                        if (spriteColors) {
+                          const template =
+                            templates[work_type.work_type] || templates.unknown;
+                          const typeSvg = template
+                            .replace('{{fillColor}}', spriteColors.fillColor)
+                            .replace(
+                              '{{strokeColor}}',
+                              spriteColors.strokeColor,
+                            )
+                            .replace(
+                              '{{multiple}}',
+                              markerSprite.work_types.length > 1
+                                ? templates.plus
+                                : '',
+                            );
+
+                          markerSprite.texture = Texture.from(typeSvg);
+                        }
+                      }
+                    } else {
+                      const { colorsKey } = markerSprite;
+                      const spriteColors = colors[colorsKey];
+                      if (spriteColors) {
+                        const template = templates.circle;
+                        const typeSvg = template
+                          .replace('{{fillColor}}', spriteColors.fillColor)
+                          .replace('{{strokeColor}}', spriteColors.strokeColor)
+                          .replace(
+                            '{{multiple}}',
+                            markerSprite.work_types.length > 1
+                              ? templates.plus
+                              : '',
+                          );
+
+                        markerSprite.texture = Texture.from(typeSvg);
+                      }
+                    }
+                    if (firstDraw) {
+                      markerSprite.scale.set(invScale);
+                    } else {
+                      markerSprite.currentScale = markerSprite.scale.x;
+                      markerSprite.targetScale = invScale;
+                    }
+                  });
+                }
+
+                let start = null;
+                const delta = 250;
+
+                function animate(timestamp) {
+                  if (start === null) start = timestamp;
+                  const progress = timestamp - start;
+                  let lambda = progress / delta;
+                  if (lambda > 1) lambda = 1;
+                  lambda *= 0.4 + lambda * (2.2 + lambda * -1.6);
+                  markerSprites.forEach(function(markerSprite) {
+                    markerSprite.scale.set(
+                      markerSprite.currentScale +
+                        lambda *
+                          (markerSprite.targetScale -
+                            markerSprite.currentScale),
+                    );
+                  });
+                  renderer.render(container);
+                  if (progress < delta) {
+                    frame = requestAnimationFrame(animate);
+                  }
+                }
+
+                if (!firstDraw && prevZoom !== zoom) {
+                  frame = requestAnimationFrame(animate);
+                }
+                firstDraw = false;
+                prevZoom = zoom;
+                prevCenter = center;
+                renderer.render(container);
+              },
+              pixiContainer,
+              {
+                doubleBuffering,
+                destroyInteractionManager: true,
+              },
+            );
+          })();
+
+          pixiLayer.addTo(map);
+          resolve();
+        });
       });
-      if (this.currentUser.states && this.currentUser.states.mapViewPort) {
-        const { _northEast, _southWest } = this.currentUser.states.mapViewPort;
-        this.map.fitBounds([
-          [_northEast.lat, _northEast.lng],
-          [_southWest.lat, _southWest.lng],
-        ]);
-      }
-      this.tileLayer.addTo(this.map);
-      this.markerLayer.addTo(this.map);
-      await this.pullSites();
     },
     async updateMap(worksite_id) {
       if (!worksite_id) {
         this.initMap();
       } else {
         const markerSprite = this.pixiContainer.children.find(
-          ms => parseInt(ms.data.id) === parseInt(worksite_id),
+          ms => parseInt(ms.id) === parseInt(worksite_id),
         );
-        markerSprite.data = Worksite.find(worksite_id);
+        const worksite = Worksite.find(worksite_id);
 
         const work_type = Worksite.getWorkType(
-          markerSprite.data.work_types,
+          worksite.work_types,
           this.currentFilters,
           this.currentUser.organization,
         );
@@ -288,11 +528,15 @@ export default {
         const colorsKey = `${work_type.status}_${
           work_type.claimed_by ? 'claimed' : 'unclaimed'
         }`;
+        markerSprite.active_work_type = work_type;
+        markerSprite.work_types = worksite.work_types;
+        markerSprite.colorsKey = colorsKey;
+
         const worksiteTemplate =
           this.map.getZoom() < INTERACTIVE_ZOOM_LEVEL
-            ? this.templates.circle
-            : this.templates[work_type.work_type] || this.templates.unknown;
-        const spriteColors = this.colors[colorsKey];
+            ? templates.circle
+            : templates[work_type.work_type] || templates.unknown;
+        const spriteColors = colors[colorsKey];
 
         if (spriteColors) {
           const svg = worksiteTemplate
@@ -300,9 +544,7 @@ export default {
             .replace('{{strokeColor}}', spriteColors.strokeColor)
             .replace(
               '{{multiple}}',
-              markerSprite.data.work_types.length > 1
-                ? this.templates.plus
-                : '',
+              markerSprite.work_types.length > 1 ? templates.plus : '',
             );
           markerSprite.texture = Texture.from(svg);
         }
@@ -315,14 +557,20 @@ export default {
     },
     goToIncidentCenter() {
       const center = averageGeolocation(
-        this.markers.map(marker => [marker.position.lat, marker.position.lng]),
+        this.markers.map(marker => [
+          marker.location.coordinates[1],
+          marker.location.coordinates[0],
+        ]),
       );
       this.map.setView([center.latitude, center.longitude], 6);
       this.showInteractivePopover = false;
     },
     goToInteractive() {
       const center = averageGeolocation(
-        this.markers.map(marker => [marker.position.lat, marker.position.lng]),
+        this.markers.map(marker => [
+          marker.location.coordinates[1],
+          marker.location.coordinates[0],
+        ]),
       );
       this.map.setView(
         [center.latitude, center.longitude],
@@ -332,15 +580,13 @@ export default {
     },
     goToLocal() {
       const center = averageGeolocation(
-        this.markers.map(marker => [marker.position.lat, marker.position.lng]),
+        this.markers.map(marker => [
+          marker.location.coordinates[1],
+          marker.location.coordinates[0],
+        ]),
       );
       this.map.setView([center.latitude, center.longitude], 15);
       this.showInteractivePopover = false;
-    },
-    addWorksite(location) {
-      this.markerLayer.clearLayers();
-      new L.marker(location).addTo(this.markerLayer);
-      this.map.setView([location.lat, location.lng], 15);
     },
     workTypesClaimedByOrganization() {
       return this.worksite.work_types.filter(
@@ -358,396 +604,15 @@ export default {
     workTypesUnclaimed() {
       return this.worksite.work_types.filter(type => type.claimed_by === null);
     },
-    loadMarkersOnMap(markers) {
-      for (let i = this.pixiContainer.children.length - 1; i >= 0; i--) {
-        this.pixiContainer.removeChild(this.pixiContainer.children[i]);
-        this.displayedWorkTypes = {};
-      }
-      this.pixiContainer.destroy({
-        children: true,
-        texture: true,
-        baseTexture: true,
-      });
-
-      this.pixiContainer = new Container();
-
-      const { map } = this;
-      const self = this;
-      const pixiLayer = (function() {
-        let firstDraw = true;
-        let prevZoom;
-        const markerSprites = [];
-        let frame = null;
-        const doubleBuffering =
-          /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
-        return L.pixiOverlay(
-          function(utils) {
-            const zoom = utils.getMap().getZoom();
-            if (frame) {
-              cancelAnimationFrame(frame);
-              frame = null;
-            }
-            const container = utils.getContainer();
-            const renderer = utils.getRenderer();
-            const project = utils.latLngToLayerPoint;
-            const scale = utils.getScale();
-            const invScale = 0.75 / scale;
-            if (firstDraw) {
-              prevZoom = zoom;
-              markers.forEach(function(marker) {
-                const coords = project([
-                  marker.position.lat,
-                  marker.position.lng,
-                ]);
-                const markerSprite = new Sprite();
-                const work_type = Worksite.getWorkType(
-                  marker.work_types,
-                  self.currentFilters,
-                  self.currentUser.organization,
-                );
-
-                self.displayedWorkTypes[work_type.work_type] = true;
-                self.displayedWorkTypes = { ...self.displayedWorkTypes };
-
-                const colorsKey = `${work_type.status}_${
-                  work_type.claimed_by ? 'claimed' : 'unclaimed'
-                }`;
-                const worksiteTemplate =
-                  zoom < INTERACTIVE_ZOOM_LEVEL
-                    ? self.templates.circle
-                    : self.templates[work_type.work_type] ||
-                      self.templates.unknown;
-                const spriteColors = self.colors[colorsKey];
-
-                if (spriteColors) {
-                  const svg = worksiteTemplate
-                    .replace('{{fillColor}}', spriteColors.fillColor)
-                    .replace('{{strokeColor}}', spriteColors.strokeColor)
-                    .replace(
-                      '{{multple}}',
-                      marker.work_types.length > 1 ? self.templates.plus : '',
-                    );
-                  markerSprite.texture = Texture.from(svg);
-                }
-                markerSprite.x = coords.x;
-                markerSprite.y = coords.y;
-                markerSprite.x0 = coords.x;
-                markerSprite.y0 = coords.y;
-                markerSprite.anchor.set(0.5, 0.5);
-                markerSprite.alpha = getOpacity(marker.updated_at);
-                container.addChild(markerSprite);
-                markerSprites.push(markerSprite);
-                markerSprite.legend = marker.city || marker.label;
-                markerSprite.data = marker;
-                // markerSprite.interactive = true;
-                // markerSprite.cursor = 'pointer';
-                // markerSprite.name = marker.case_number;
-                // markerSprite.on('click', () => {
-                //     self.onSelectmarker(marker);
-                // });
-              });
-
-              const quadTrees = {};
-              for (let z = INTERACTIVE_ZOOM_LEVEL; z <= map.getMaxZoom(); z++) {
-                const rInit = (z <= 7 ? 16 : 24) / utils.getScale(z);
-                quadTrees[z] = solveCollision(markerSprites, {
-                  r0: rInit,
-                  zoom: z,
-                });
-              }
-              const findMarker = ll => {
-                if (utils.getMap().getZoom() < INTERACTIVE_ZOOM_LEVEL) {
-                  return null;
-                }
-                const layerPoint = project(ll);
-                const quadTree = quadTrees[utils.getMap().getZoom()];
-                let marker;
-                const { rMax } = quadTree;
-                let found = false;
-                quadTree.visit(function(quad, x1, y1, x2, y2) {
-                  if (!quad.length) {
-                    const dx = quad.data.x - layerPoint.x;
-                    const dy = quad.data.y - layerPoint.y;
-                    const r = quad.data.scale.x * 16;
-                    if (dx * dx + dy * dy <= r * r) {
-                      marker = quad.data;
-                      found = true;
-                    }
-                  }
-                  return (
-                    found ||
-                    x1 > layerPoint.x + rMax ||
-                    x2 + rMax < layerPoint.x ||
-                    y1 > layerPoint.y + rMax ||
-                    y2 + rMax < layerPoint.y
-                  );
-                });
-                return marker;
-              };
-
-              map.on('click', function(e) {
-                const marker = findMarker(e.latlng);
-                if (marker) {
-                  self.$emit('onSelectmarker', marker.data);
-                } else {
-                  map.closePopup();
-                }
-
-                if (utils.getMap().getZoom() < INTERACTIVE_ZOOM_LEVEL) {
-                  self.showInteractivePopover = true;
-                }
-              });
-
-              map.on(
-                'mousemove',
-                L.Util.throttle(e => {
-                  const marker = findMarker(e.latlng);
-                  if (marker) {
-                    L.DomUtil.addClass(this._container, 'cursor-pointer');
-                  } else {
-                    L.DomUtil.removeClass(this._container, 'cursor-pointer');
-                  }
-                }, 32),
-              );
-            }
-            if (firstDraw || prevZoom !== zoom) {
-              markerSprites.forEach(function(markerSprite) {
-                const work_type = Worksite.getWorkType(
-                  markerSprite.data.work_types,
-                  self.currentFilters,
-                  self.currentUser.organization,
-                );
-
-                const colorsKey = `${work_type.status}_${
-                  work_type.claimed_by ? 'claimed' : 'unclaimed'
-                }`;
-                const worksiteTemplate =
-                  zoom < INTERACTIVE_ZOOM_LEVEL
-                    ? self.templates.circle
-                    : self.templates[work_type.work_type] ||
-                      self.templates.unknown;
-                const spriteColors = self.colors[colorsKey];
-
-                if (spriteColors) {
-                  const svg = worksiteTemplate
-                    .replace('{{fillColor}}', spriteColors.fillColor)
-                    .replace('{{strokeColor}}', spriteColors.strokeColor)
-                    .replace(
-                      '{{multiple}}',
-                      markerSprite.data.work_types.length > 1
-                        ? self.templates.plus
-                        : '',
-                    );
-                  markerSprite.texture = Texture.from(svg);
-                }
-
-                if (firstDraw) {
-                  markerSprite.scale.set(invScale);
-                } else {
-                  markerSprite.currentScale = markerSprite.scale.x;
-                  markerSprite.targetScale = invScale;
-                }
-              });
-            }
-
-            let start = null;
-            const delta = 250;
-
-            function animate(timestamp) {
-              if (start === null) start = timestamp;
-              const progress = timestamp - start;
-              let lambda = progress / delta;
-              if (lambda > 1) lambda = 1;
-              lambda *= 0.4 + lambda * (2.2 + lambda * -1.6);
-              markerSprites.forEach(function(markerSprite) {
-                markerSprite.scale.set(
-                  markerSprite.currentScale +
-                    lambda *
-                      (markerSprite.targetScale - markerSprite.currentScale),
-                );
-              });
-              renderer.render(container);
-              if (progress < delta) {
-                frame = requestAnimationFrame(animate);
-              }
-            }
-
-            if (!firstDraw && prevZoom !== zoom) {
-              frame = requestAnimationFrame(animate);
-            }
-            firstDraw = false;
-            prevZoom = zoom;
-            renderer.render(container);
-          },
-          self.pixiContainer,
-          {
-            doubleBuffering,
-            reloadOnAdd: true,
-          },
-        );
-      })();
-      pixiLayer.addTo(map);
-    },
-    async pullSites(url) {
-      if (!this.query.incident) {
-        return;
-      }
-      this.mapLoading = true;
-      try {
-        const response = await this.$http.get(
-          url || `${process.env.VUE_APP_API_BASE_URL}/worksites_all`,
-          {
-            params: url ? {} : { ...this.query },
-          },
-        );
-
-        this.markers = response.data.results.map(worksite => {
-          return {
-            ...worksite,
-            position: {
-              lat: worksite.location ? worksite.location.coordinates[1] : 10,
-              lng: worksite.location ? worksite.location.coordinates[0] : 10,
-            },
-          };
-        });
-      } catch (e) {
-        this.markers = [];
-      }
-
-      this.$log.debug(`Loading ${this.markers.length} markers`);
-      await this.loadMarkersOnMap(this.markers);
-      this.$nextTick(() => {
-        // Add this slight pan to re-render map
-        this.map.panBy([1, 0]);
-      });
-      this.mapLoading = false;
-    },
   },
 };
 </script>
 
 <style>
 @import '~leaflet/dist/leaflet.css';
-@import '~leaflet-loading/src/Control.Loading.css';
-@import '~leaflet.markercluster/dist/MarkerCluster.Default.css';
-@import '~leaflet.markercluster/dist/MarkerCluster.css';
-
-/*.home-map {*/
-/*    height: 100%;*/
-/*}*/
 
 .map-svg-container svg {
   width: 25px;
   height: 25px;
-}
-
-.leaflet-pane {
-  z-index: 5;
-}
-
-.interactive-tooltip {
-  display: block !important;
-  z-index: 10000;
-}
-
-.interactive-tooltip .tooltip-inner {
-  background: black;
-  color: white;
-  border-radius: 16px;
-  padding: 5px 10px 4px;
-}
-
-.interactive-tooltip .tooltip-arrow {
-  width: 0;
-  height: 0;
-  border-style: solid;
-  position: absolute;
-  margin: 5px;
-  border-color: black;
-  z-index: 1;
-}
-
-.interactive-tooltip[x-placement^='top'] {
-  margin-bottom: 5px;
-}
-
-.interactive-tooltip[x-placement^='top'] .tooltip-arrow {
-  border-width: 5px 5px 0 5px;
-  border-left-color: transparent !important;
-  border-right-color: transparent !important;
-  border-bottom-color: transparent !important;
-  bottom: -5px;
-  left: calc(50% - 5px);
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.interactive-tooltip[x-placement^='bottom'] {
-  margin-top: 5px;
-}
-
-.interactive-tooltip[x-placement^='bottom'] .tooltip-arrow {
-  border-width: 0 5px 5px 5px;
-  border-left-color: transparent !important;
-  border-right-color: transparent !important;
-  border-top-color: transparent !important;
-  top: -5px;
-  left: calc(50% - 5px);
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.interactive-tooltip[x-placement^='right'] {
-  margin-left: 5px;
-}
-
-.interactive-tooltip[x-placement^='right'] .tooltip-arrow {
-  border-width: 5px 5px 5px 0;
-  border-left-color: transparent !important;
-  border-top-color: transparent !important;
-  border-bottom-color: transparent !important;
-  left: -5px;
-  top: calc(50% - 5px);
-  margin-left: 0;
-  margin-right: 0;
-}
-
-.interactive-tooltip[x-placement^='left'] {
-  margin-right: 5px;
-}
-
-.interactive-tooltip[x-placement^='left'] .tooltip-arrow {
-  border-width: 5px 0 5px 5px;
-  border-top-color: transparent !important;
-  border-right-color: transparent !important;
-  border-bottom-color: transparent !important;
-  right: -5px;
-  top: calc(50% - 5px);
-  margin-left: 0;
-  margin-right: 0;
-}
-
-.interactive-tooltip.popover .popover-inner {
-  background: #f9f9f9;
-  color: black;
-  padding: 24px;
-  border-radius: 5px;
-  box-shadow: 0 5px 30px rgba(black, 0.1);
-}
-
-.interactive-tooltip.popover .popover-arrow {
-  border-color: #f9f9f9;
-}
-
-.interactive-tooltip[aria-hidden='true'] {
-  visibility: hidden;
-  opacity: 0;
-  transition: opacity 0.15s, visibility 0.15s;
-}
-
-.interactive-tooltip[aria-hidden='false'] {
-  visibility: visible;
-  opacity: 1;
-  transition: opacity 0.15s;
 }
 </style>

--- a/src/icons/icons_templates.js
+++ b/src/icons/icons_templates.js
@@ -74,7 +74,7 @@ const colors = {
 };
 
 const circle = `<svg xmlns="http://www.w3.org/2000/svg" height="18" width="18">
-                <circle cx="9" cy="9" r="9" stroke="white" stroke-width="1.5" fill="{{fillColor}}" />
+                <circle cx="9" cy="9" r="9" stroke="white" stroke-width="0.5" fill="{{fillColor}}" />
               </svg>`;
 
 const plus = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="30" y="30">

--- a/src/pages/Cases.vue
+++ b/src/pages/Cases.vue
@@ -179,7 +179,6 @@
               :new-marker="newMarker"
               :current-filters="filters"
               @mapMoved="onMapMoved"
-              @initMap="onInitMap"
               @onSelectmarker="displayWorksite"
             />
           </template>
@@ -539,12 +538,8 @@ export default {
       });
     },
 
-    onInitMap(map) {
-      this.map = map;
-    },
-
     applyLayers(value, layerList, key) {
-      if (value && this.map) {
+      if (value && this.$refs.workstiteMap.map) {
         // TODO: Refactor to abide with code style
         // eslint-disable-next-line no-restricted-syntax
         for (const location of layerList) {
@@ -557,19 +552,19 @@ export default {
             onEachFeature(feature, layer) {
               layer.key = key;
             },
-          }).addTo(this.map);
+          }).addTo(this.$refs.workstiteMap.map);
         }
       } else {
-        this.map.eachLayer(layer => {
+        this.$refs.workstiteMap.map.eachLayer(layer => {
           if (layer.key && layer.key === key) {
-            this.map.removeLayer(layer);
+            this.$refs.workstiteMap.map.removeLayer(layer);
           }
         });
       }
     },
 
     async applyLocation(location_id, value) {
-      if (value && this.map) {
+      if (value && this.$refs.workstiteMap.map) {
         await Location.api().fetchById(location_id);
         const location = Location.find(location_id);
         const geojsonFeature = {
@@ -581,12 +576,12 @@ export default {
           onEachFeature(feature, layer) {
             layer.location_id = location_id;
           },
-        }).addTo(this.map);
+        }).addTo(this.$refs.workstiteMap.map);
         this.appliedLocations.add(location_id);
       } else {
-        this.map.eachLayer(layer => {
+        this.$refs.workstiteMap.map.eachLayer(layer => {
           if (layer.location_id && layer.location_id === location_id) {
-            this.map.removeLayer(layer);
+            this.$refs.workstiteMap.map.removeLayer(layer);
           }
         });
         this.appliedLocations.delete(location_id);
@@ -822,7 +817,9 @@ export default {
       window.URL.revokeObjectURL(url);
     },
     addMarkerToMap(location) {
-      this.newMarker = location;
+      this.$refs.workstiteMap.markerLayer.clearLayers();
+      new L.marker(location).addTo(this.$refs.workstiteMap.markerLayer);
+      this.$refs.workstiteMap.map.setView([location.lat, location.lng], 15);
       this.toggleView('showingMap');
     },
   },


### PR DESCRIPTION
#Changes

- Remove a lot of unnecessary reactivity from map that was making it really heavy
- Only render individual worksite icons when on the right view level AND are within the right viewport
- Remember different states on Sprites so calculation do no need to be done for every render