### PR TITLE
Add table sorting for cases table

### DIFF
--- a/src/assets/icons/updown.svg
+++ b/src/assets/icons/updown.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="24" height="24" viewBox="0 0 24 24">
+  <defs>
+    <path id="a" d="M3.344 0h1.312v9.438l2.407-2.376L8 8l-4 4-4-4 .938-.938 2.406 2.375z"/>
+  </defs>
+  <g fill="none" fill-rule="evenodd" transform="translate(11 10)">
+    <mask id="b" fill="#fff">
+      <use xlink:href="#a"/>
+    </mask>
+    <use fill="#333" xlink:href="#a"/>
+    <g fill="#333" mask="url(#b)">
+      <path d="M-32-30h72v72h-72z"/>
+    </g>
+  </g>
+
+  <defs>
+    <path id="c" d="M3.344 12V2.562L.938 4.938 0 4l4-4 4 4-.938.938-2.406-2.375V12z"/>
+  </defs>
+  <g fill="none" fill-rule="evenodd" transform="translate(5 2)">
+    <mask id="d" fill="#fff">
+      <use xlink:href="#c"/>
+    </mask>
+    <use fill="#333" xlink:href="#c"/>
+    <g fill="#333" mask="url(#d)">
+      <path d="M-32-30h72v72h-72z"/>
+    </g>
+  </g>
+</svg>

--- a/src/components/BaseIcon.vue
+++ b/src/components/BaseIcon.vue
@@ -22,6 +22,9 @@ const iconMap = {
   history: require('@/assets/icons/history.svg'),
   cancel: require('@/assets/icons/big.svg'),
   help: require('@/assets/icons/help.svg'),
+  up: require('@/assets/icons/up.svg'),
+  down: require('@/assets/icons/down.svg'),
+  updown: require('@/assets/icons/updown.svg'),
   'go-case': require('@/assets/icons/replace-case.svg'),
 };
 export default {

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -7,9 +7,36 @@
       <div
         v-for="column of columns"
         :key="column.key"
-        class="p-2 border-b flex items-center"
+        class="p-2 border-b flex items-center cursor-pointer"
+        @click="
+          () => {
+            if (column.sortable) {
+              sort(column.key);
+            }
+          }
+        "
       >
         {{ column.title }}
+        <div v-if="column.sortable">
+          <ccu-icon
+            v-if="sorter.key === column.key && sorter.direction === 'asc'"
+            :alt="$t('actions.sort_ascending')"
+            size="small"
+            type="up"
+          />
+          <ccu-icon
+            v-else-if="sorter.key === column.key && sorter.direction === 'desc'"
+            :alt="$t('actions.sort_descending')"
+            size="small"
+            type="down"
+          />
+          <ccu-icon
+            v-else
+            :alt="$t('actions.sortable')"
+            size="small"
+            type="updown"
+          />
+        </div>
       </div>
     </div>
     <div class="body bg-white relative" :style="gridStyleBody">
@@ -116,6 +143,12 @@ export default {
     columns: Array,
     data: Array,
     pagination: Object,
+    sorter: {
+      type: Object,
+      default: () => {
+        return {};
+      },
+    },
     loading: Boolean,
     enableSelection: Boolean,
     enablePagniation: Boolean,
@@ -251,7 +284,9 @@ export default {
         page: newPage,
       };
       const filter = {};
-      const sorter = {};
+      const sorter = {
+        ...this.sorter,
+      };
       this.$emit('change', { pagination, filter, sorter });
     },
     onSelectPageSize(pageSize) {
@@ -261,7 +296,24 @@ export default {
         pageSize,
       };
       const filter = {};
-      const sorter = {};
+      const sorter = {
+        ...this.sorter,
+      };
+      this.$emit('change', { pagination, filter, sorter });
+    },
+    sort(key) {
+      const sorter = { ...this.sorter };
+      sorter.key = key;
+      if (sorter.direction === 'asc') {
+        sorter.direction = 'desc';
+      } else {
+        sorter.direction = 'asc';
+      }
+
+      const pagination = {
+        ...this.pagination,
+      };
+      const filter = {};
       this.$emit('change', { pagination, filter, sorter });
     },
     rowClick(item) {

--- a/src/components/__tests__/Table.test.js
+++ b/src/components/__tests__/Table.test.js
@@ -128,6 +128,50 @@ describe('Table', () => {
     expect(wrapper.vm.pagination).toMatchSnapshot();
   });
 
+  it('should handle sort correctly from cold', () => {
+    const wrapper = mountWithOptions({
+      props: {
+        sorter: {
+          key: null,
+          direction: null,
+        },
+        pagination: {
+          pageSize: 5,
+          page: 1,
+          current: 1,
+        },
+      },
+    });
+    wrapper.vm.sort('id');
+    expect(wrapper.vm.pagination).toMatchSnapshot();
+    expect(wrapper.emitted().change[0][0].sorter).toEqual({
+      key: 'id',
+      direction: 'asc',
+    });
+  });
+
+  it('should handle sort correctly with existing sort', () => {
+    const wrapper = mountWithOptions({
+      props: {
+        sorter: {
+          key: 'id',
+          direction: 'asc',
+        },
+        pagination: {
+          pageSize: 5,
+          page: 1,
+          current: 1,
+        },
+      },
+    });
+    wrapper.vm.sort('id');
+    expect(wrapper.vm.pagination).toMatchSnapshot();
+    expect(wrapper.emitted().change[0][0].sorter).toEqual({
+      key: 'id',
+      direction: 'desc',
+    });
+  });
+
   it('should render correctly and match snapshot', () => {
     const wrapper = mountWithOptions();
     expect(wrapper.element).toMatchSnapshot();

--- a/src/components/__tests__/__snapshots__/Table.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Table.test.js.snap
@@ -40,6 +40,22 @@ Object {
 }
 `;
 
+exports[`Table should handle sort correctly from cold 1`] = `
+Object {
+  "current": 1,
+  "page": 1,
+  "pageSize": 5,
+}
+`;
+
+exports[`Table should handle sort correctly with existing sort 1`] = `
+Object {
+  "current": 1,
+  "page": 1,
+  "pageSize": 5,
+}
+`;
+
 exports[`Table should render correctly and match snapshot 1`] = `
 <div
   class="table w-full"
@@ -51,18 +67,20 @@ exports[`Table should render correctly and match snapshot 1`] = `
     <!---->
      
     <div
-      class="p-2 border-b flex items-center"
+      class="p-2 border-b flex items-center cursor-pointer"
     >
       
       One
-    
+      
+      <!---->
     </div>
     <div
-      class="p-2 border-b flex items-center"
+      class="p-2 border-b flex items-center cursor-pointer"
     >
       
       Two
-    
+      
+      <!---->
     </div>
   </div>
    
@@ -147,18 +165,20 @@ exports[`Table should render correctly with selection and pagination 1`] = `
     </div>
      
     <div
-      class="p-2 border-b flex items-center"
+      class="p-2 border-b flex items-center cursor-pointer"
     >
       
       One
-    
+      
+      <!---->
     </div>
     <div
-      class="p-2 border-b flex items-center"
+      class="p-2 border-b flex items-center cursor-pointer"
     >
       
       Two
-    
+      
+      <!---->
     </div>
   </div>
    

--- a/src/models/Worksite.js
+++ b/src/models/Worksite.js
@@ -15,7 +15,7 @@ export default class Worksite extends Model {
       case_number: this.attr(null),
       city: this.attr(null),
       county: this.attr(null),
-      form_data: this.attr(null),
+      form_data: this.attr([]),
       postal_code: this.attr(null),
       map_location: this.attr(null),
       incident: this.attr(null),


### PR DESCRIPTION
This sort currently is only for base fields on the worksite. Once we add the ability to see extended fields in 3.1 https://github.com/CrisisCleanup/crisiscleanup-4-web/issues/167 we will add sorting for those