### PR TITLE
Changes to bulk csv download

### DIFF
--- a/src/components/WorksiteMap.vue
+++ b/src/components/WorksiteMap.vue
@@ -241,6 +241,11 @@ export default {
         const loader = new Loader();
         loader.add('circle', '/circle.svg');
         loader.load(() => {
+          const container = L.DomUtil.get('map');
+          if (container !== null) {
+            container._leaflet_id = null;
+          }
+
           if (!this.map) {
             this.map = L.map('map', { zoomControl: false }).setView(
               [31.0, -100.0],

--- a/src/models/Worksite.js
+++ b/src/models/Worksite.js
@@ -268,10 +268,13 @@ export default class Worksite extends Model {
       },
       // TODO: handle exceptions and ensure a value is returned
       // eslint-disable-next-line consistent-return
-      downloadWorksite(id) {
+      downloadWorksite(ids) {
+        if (!ids.length) {
+          throw Error('Ids are required');
+        }
         try {
           return this.request({
-            url: `/worksites/${id}`,
+            url: `/worksites?id__in=${ids.join(',')}`,
             method: 'GET',
             responseType: 'blob',
             headers: { Accept: 'text/csv' },

--- a/src/pages/Cases.vue
+++ b/src/pages/Cases.vue
@@ -194,7 +194,11 @@
                       <base-button
                         class="text-base font-thin mx-4"
                         :text="$t('actions.download')"
-                        :action="() => batchAction(downloadWorksite)"
+                        :action="
+                          () => {
+                            downloadSelectedWorksites();
+                          }
+                        "
                         data-cy="worksiteview_actionBatchDownload"
                       />
                     </li>
@@ -1125,8 +1129,16 @@ export default {
     },
     async downloadWorksite(e, siteId) {
       this.spinning = true;
-      const csv = await Worksite.api().downloadWorksite(
+      const csv = await Worksite.api().downloadWorksite([
         siteId || this.currentWorksite.id,
+      ]);
+      forceFileDownload(csv.response);
+      this.spinning = false;
+    },
+    async downloadSelectedWorksites() {
+      this.spinning = true;
+      const csv = await Worksite.api().downloadWorksite(
+        Array.from(this.selectedTableItems),
       );
       forceFileDownload(csv.response);
       this.spinning = false;


### PR DESCRIPTION
Add a small tweak to the api to make csv download based on a filter, this way we might able to avoid batch processing as a specific case. I'm thinking of doing something similarly simple for the pdf downloads


See https://github.com/CrisisCleanup/crisiscleanup-3-api/commit/18066ba1adb126631a2295656ba21ab43b14df44 for the API change

@BradenM what do you think?