### PR TITLE
ci: Implement Sorry Cypress Dashboard

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -47,6 +47,11 @@ jobs:
     name: Run Visual Tests
     runs-on: ubuntu-16.04
     needs: build_id
+    strategy:
+      fail-fast: false
+      matrix:
+        # run 3 instances of cypress in parallel
+        containers: [1, 2, 3]
 
     steps:
       - uses: actions/checkout@v2
@@ -81,6 +86,7 @@ jobs:
         uses: cypress-io/github-action@v1.23.0
         with:
           record: true
+          parallel: true
           start: 'yarn cy:patch && yarn serve'
           wait-on: 'http://localhost:8080'
           browser: chrome

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,33 +16,6 @@ env:
   VUE_APP_API_BASE_URL: 'https://api.staging.crisiscleanup.io'
 
 jobs:
-  build_id:
-    # allows for:
-    # 1.) Parallel Builds
-    # 2.) Multiple builds per commit hash (think PR & Branch)
-    name: Generate Unique Build ID
-    runs-on: ubuntu-16.04
-    steps:
-      - name: Set Build ID
-        id: build_id
-        run: echo "::set-output name=id::$(date +%s)"
-
-      - name: Cache Build ID
-        uses: actions/cache@v1.0.3
-        with:
-          path: ${{ github.workspace }}/.build-id
-          # use build id for unique cache
-          key: ${{ runner.os }}-build-id-${{ github.head_ref }}-${{ github.sha }}-${{ steps.build_id.outputs.id }}
-
-      - name: Save Build ID
-        run: |
-          mkdir -p "$BUILD_DIR"
-          echo "$BUILD_ID" > "$BUILD_PATH"
-        env:
-          BUILD_ID: ${{ steps.build_id.outputs.id }}
-          BUILD_DIR: ${{ github.workspace }}/.build-id
-          BUILD_PATH: ${{ github.workspace }}/.build-id/id
-
   cypress:
     name: Run Visual Tests
     runs-on: ubuntu-16.04
@@ -55,19 +28,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-
-      - name: Cache Build ID
-        uses: actions/cache@v1.0.3
-        with:
-          path: ${{ github.workspace }}/.build-id
-          # unique build ID
-          key: ${{ runner.os }}-build-id-${{ github.head_ref }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-build-id-${{ github.head_ref }}-${{ github.sha }}
-
-      - name: Set Build ID
-        id: build_id
-        run: echo "::set-output name=id::$(cat .build-id/id)"
 
       - name: Checkout Api
         uses: actions/checkout@v2
@@ -93,7 +53,6 @@ jobs:
           headless: true
           cache-key: yarn-${{ hashFiles('**/yarn.lock') }}
           command-prefix: 'percy exec -- npx'
-          ci-build-id: '${{ github.sha }}-${{ github.workflow }}-${{ github.event_name }}'
           env: WEB_USER=${{ secrets.CYPRESS_WEB_USER }},WEB_PASS=${{ secrets.CYPRESS_WEB_PASS }},API_URL=http://localhost:5000
         env:
           VUE_APP_API_BASE_URL: 'http://localhost:5000'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -81,7 +81,7 @@ jobs:
         uses: cypress-io/github-action@v1.23.0
         with:
           record: true
-          start: yarn cy:patch && yarn serve
+          start: 'yarn cy:patch && yarn serve'
           wait-on: 'http://localhost:8080'
           browser: chrome
           headless: true
@@ -97,3 +97,4 @@ jobs:
           CYPRESS_API_URL: 'http://localhost:5000'
           SORRY_CYP_API_URL: ${{ secrets.SORRY_CYP_API_URL }}
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,7 +19,6 @@ jobs:
   cypress:
     name: Run Visual Tests
     runs-on: ubuntu-16.04
-    needs: build_id
     strategy:
       fail-fast: false
       matrix:
@@ -42,13 +41,27 @@ jobs:
           docker-compose build --pull
           docker-compose up -d app
 
-      - name: Run Cypress
-        uses: cypress-io/github-action@v1.23.0
+      - name: Install Dependencies
+        uses: cypress-io/github-action@v1.23.1
         with:
+          # will install node deps & cypress
+          runTests: false
+
+      - name: Patch Cypress Director
+        env:
+          SORRY_CYP_API_URL: ${{ secrets.SORRY_CYP_API_URL }}
+        run: yarn cy:patch
+
+      - name: Run Cypress
+        uses: cypress-io/github-action@v1.23.1
+        with:
+          # skip install now
+          install: false
           record: true
           parallel: true
-          start: 'yarn cy:patch && yarn serve'
+          start: yarn serve
           wait-on: 'http://localhost:8080'
+          wait-on-timeout: 120
           browser: chrome
           headless: true
           cache-key: yarn-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -80,8 +80,8 @@ jobs:
       - name: Run Cypress
         uses: cypress-io/github-action@v1.23.0
         with:
-          record: false
-          start: yarn serve
+          record: true
+          start: yarn cy:patch && yarn serve
           wait-on: 'http://localhost:8080'
           browser: chrome
           headless: true
@@ -95,4 +95,5 @@ jobs:
           CYPRESS_WEB_USER: ${{ secrets.CYPRESS_WEB_USER }}
           CYPRESS_WEB_PASS: ${{ secrets.CYPRESS_WEB_PASS }}
           CYPRESS_API_URL: 'http://localhost:5000'
+          SORRY_CYP_API_URL: ${{ secrets.SORRY_CYP_API_URL }}
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}

--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://on.cypress.io/cypress.schema.json",
   "baseUrl": "http://localhost:8080",
   "env": {
     "NODE_ENV": "test",
@@ -8,7 +7,6 @@
   },
   "ignoreTestFiles": ["**/__snapshots__/*", "**/__image_snapshots__/*"],
   "projectId": "xyprfc",
-  "video": false,
   "viewportHeight": 900,
   "viewportWidth": 1400
 }

--- a/internal/scripts/patchCypress.js
+++ b/internal/scripts/patchCypress.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+
+/*
+ * Patch Cypress API Url
+ *
+ */
+
+const shelljs = require('shelljs');
+const path = require('path');
+
+const getConfigPath = cypBin => {
+  shelljs.env.DEBUG = 'cypress:*';
+  const output = shelljs.exec(`${cypBin} version`, {
+    silent: true,
+    shell: shelljs.which('bash'),
+  }).stderr;
+  const searchStr = 'Reading binary package.json from: ';
+  const pathStart = output.search(searchStr);
+  const pathStdout = output.slice(pathStart + searchStr.length).split(' ')[0];
+  return path.resolve(pathStdout, '../packages/server/config/app.yml');
+};
+
+// Paths
+const rootDir = path.resolve(__dirname, '../../');
+const cypressBin = path.resolve(rootDir, 'node_modules/.bin/cypress');
+const apiCypress = 'https://api.cypress.io/';
+
+// API Url to Set
+const apiUrl = shelljs.env.SORRY_CYP_API_URL;
+
+shelljs.echo(`Patching Cypress Api`);
+shelljs.echo(`Found project root: ${rootDir}`);
+shelljs.echo(`Cypress Binary: ${cypressBin}`);
+
+const cypConfig = getConfigPath(cypressBin);
+shelljs.echo(`Found Cypress Config: ${cypConfig}`);
+
+shelljs.echo('\nPatching...');
+shelljs.sed('-i', apiCypress, apiUrl, cypConfig);
+shelljs.echo('Done!');

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:cy": "cross-env NODE_ENV=test cypress run --browser chrome",
     "test:percy": "cross-env NODE_ENV=test percy exec -- yarn run test:cy",
     "cy:open": "cross-env NODE_ENV=test cypress open",
+    "cy:patch": "node ./internal/scripts/patchCypress.js",
     "storybook": "cross-env NODE_ENV=development start-storybook -p 6006",
     "build-storybook": "cross-env NODE_ENV=test build-storybook"
   },
@@ -145,6 +146,7 @@
     "lint-staged": "^10.0.8",
     "nyc": "^15.0.0",
     "prettier": "^1.19.1",
+    "shelljs": "^0.8.3",
     "storybook-addon-vue-info": "^1.4.2",
     "tailwindcss": "^1.2.0",
     "vue-docgen-api": "^4.13.1",


### PR DESCRIPTION
**Changes**

* Implement [sorry-cypress](https://github.com/agoldis/sorry-cypress) as a free cypress dashboard alternative
* added script for auto-patching cypress director API url
* added `cy:patch` command for executing above script
* deployed sorry-cypress AWS stack
* added CNAME entry to point to our dashboard

See: http://cypress.crisiscleanup.io