### PR TITLE
Call history table

### DIFF
--- a/src/components/phone/CallHistory.vue
+++ b/src/components/phone/CallHistory.vue
@@ -7,7 +7,11 @@
       <th>Notes</th>
       <th>Call Completed</th>
     </div>
-    <call-summary />
+    <call-summary
+      v-for="(detail, idx) in details"
+      :key="idx"
+      :phone="detail.phone"
+    ></call-summary>
   </div>
 </template>
 <script>
@@ -16,6 +20,20 @@ export default {
   name: 'CallHistory',
   components: {
     CallSummary,
+  },
+  computed: {
+    details() {
+      return [
+        {
+          phone: this.$t('601-123-4567'),
+          name: this.$t('John Doe'),
+          caseNumber: this.$t('C11'),
+          callStatus: this.$t('Call Status'),
+          notes: this.$t('asldfjasdkfjasldfjd'),
+          callCompleted: this.$t('10 mins ago'),
+        },
+      ];
+    },
   },
 };
 </script>

--- a/src/components/phone/CallHistory.vue
+++ b/src/components/phone/CallHistory.vue
@@ -1,3 +1,14 @@
+<template>
+  <div>
+    <div class="flex flex-row justify-between">
+      <th>Phone Number</th>
+      <th>Case #</th>
+      <th>Call Status</th>
+      <th>Notes</th>
+      <th>Call Completed</th>
+    </div>
+  </div>
+</template>
 <script>
 export default {
   name: 'CallHistory',

--- a/src/components/phone/CallHistory.vue
+++ b/src/components/phone/CallHistory.vue
@@ -7,10 +7,15 @@
       <th>Notes</th>
       <th>Call Completed</th>
     </div>
+    <call-summary />
   </div>
 </template>
 <script>
+import CallSummary from '@/components/phone/CallSummary.vue';
 export default {
   name: 'CallHistory',
+  components: {
+    CallSummary,
+  },
 };
 </script>

--- a/src/components/phone/CallHistory.vue
+++ b/src/components/phone/CallHistory.vue
@@ -1,53 +1,55 @@
 <template>
   <div>
     <table>
-      <tr>
-        <th>
-          <base-text
-            variant="bodysm"
-            weight="900"
-            class="text-crisiscleanup-dark-300"
-          >
-            Phone Number
-          </base-text>
-        </th>
-        <th>
-          <base-text
-            variant="bodysm"
-            weight="900"
-            class="text-crisiscleanup-dark-300"
-          >
-            Case #
-          </base-text>
-        </th>
-        <th>
-          <base-text
-            variant="bodysm"
-            weight="900"
-            class="text-crisiscleanup-dark-300"
-          >
-            Call Status
-          </base-text>
-        </th>
-        <th>
-          <base-text
-            variant="bodysm"
-            weight="900"
-            class="text-crisiscleanup-dark-300"
-          >
-            Notes
-          </base-text>
-        </th>
-        <th>
-          <base-text
-            variant="bodysm"
-            weight="900"
-            class="text-crisiscleanup-dark-300"
-          >
-            Call Completed
-          </base-text>
-        </th>
-      </tr>
+      <thead>
+        <tr>
+          <th>
+            <base-text
+              variant="bodysm"
+              weight="900"
+              class="text-crisiscleanup-dark-300"
+            >
+              Phone Number
+            </base-text>
+          </th>
+          <th>
+            <base-text
+              variant="bodysm"
+              weight="900"
+              class="text-crisiscleanup-dark-300"
+            >
+              Case #
+            </base-text>
+          </th>
+          <th>
+            <base-text
+              variant="bodysm"
+              weight="900"
+              class="text-crisiscleanup-dark-300"
+            >
+              Call Status
+            </base-text>
+          </th>
+          <th>
+            <base-text
+              variant="bodysm"
+              weight="900"
+              class="text-crisiscleanup-dark-300"
+            >
+              Notes
+            </base-text>
+          </th>
+          <th>
+            <base-text
+              variant="bodysm"
+              weight="900"
+              class="text-crisiscleanup-dark-300"
+            >
+              Call Completed
+            </base-text>
+          </th>
+        </tr>
+      </thead>
     </table>
     <call-summary
       v-for="(detail, idx) in details"
@@ -93,6 +95,10 @@ export default {
     minmax(150px, 1.67fr)
     minmax(150px, 3.33fr)
     minmax(150px, 1fr);
+}
+thead,
+tr {
+  display: contents;
 }
 th {
   /* position: sticky;

--- a/src/components/phone/CallHistory.vue
+++ b/src/components/phone/CallHistory.vue
@@ -88,7 +88,7 @@ export default {
   flex: 1;
   border-collapse: collapse;
   grid-template-columns:
-    minmax(150px, 3.33fr)
+    minmax(150px, 5.44fr)
     minmax(150px, 1.67fr)
     minmax(150px, 1.67fr)
     minmax(150px, 3.33fr)

--- a/src/components/phone/CallHistory.vue
+++ b/src/components/phone/CallHistory.vue
@@ -9,6 +9,8 @@
         Phone Number
       </base-text>
 
+      <div class="box b" />
+
       <base-text
         variant="bodysm"
         weight="900"

--- a/src/components/phone/CallHistory.vue
+++ b/src/components/phone/CallHistory.vue
@@ -1,0 +1,5 @@
+<script>
+export default {
+  name: 'CallHistory',
+};
+</script>

--- a/src/components/phone/CallHistory.vue
+++ b/src/components/phone/CallHistory.vue
@@ -1,53 +1,59 @@
 <template>
   <div>
     <div class="wrapper">
-      <base-text
-        variant="bodysm"
-        weight="900"
-        class="text-crisiscleanup-dark-300"
-      >
-        Phone Number
-      </base-text>
-
+      <div class="box a">
+        <base-text
+          variant="bodysm"
+          weight="900"
+          class="text-crisiscleanup-dark-300"
+        >
+          Phone Number
+        </base-text>
+      </div>
       <div class="box b" />
-
-      <base-text
-        variant="bodysm"
-        weight="900"
-        class="text-crisiscleanup-dark-300"
-      >
-        Case #
-      </base-text>
-
-      <base-text
-        variant="bodysm"
-        weight="900"
-        class="text-crisiscleanup-dark-300"
-      >
-        Call Status
-      </base-text>
-
-      <base-text
-        variant="bodysm"
-        weight="900"
-        class="text-crisiscleanup-dark-300"
-      >
-        Notes
-      </base-text>
-
-      <base-text
-        variant="bodysm"
-        weight="900"
-        class="text-crisiscleanup-dark-300"
-      >
-        Call Completed
-      </base-text>
+      <div class="box c">
+        <base-text
+          variant="bodysm"
+          weight="900"
+          class="text-crisiscleanup-dark-300"
+        >
+          Case #
+        </base-text>
+      </div>
+      <div class="box d">
+        <base-text
+          variant="bodysm"
+          weight="900"
+          class="text-crisiscleanup-dark-300"
+        >
+          Call Status
+        </base-text>
+      </div>
+      <div class="box e">
+        <base-text
+          variant="bodysm"
+          weight="900"
+          class="text-crisiscleanup-dark-300"
+        >
+          Notes
+        </base-text>
+      </div>
+      <div class="box f">
+        <base-text
+          variant="bodysm"
+          weight="900"
+          class="text-crisiscleanup-dark-300"
+        >
+          Call Completed
+        </base-text>
+      </div>
     </div>
     <call-summary
       v-for="(detail, idx) in details"
       :key="idx"
       :phone="detail.phone"
     ></call-summary>
+    <call-summary />
   </div>
 </template>
 <script>
@@ -84,5 +90,9 @@ export default {
   grid-column: auto;
   display: grid;
   grid-template-columns: repeat(6, minmax(50px, 1fr));
+}
+.box {
+  border-radius: 5px;
+  padding: 5px;
 }
 </style>

--- a/src/components/phone/CallHistory.vue
+++ b/src/components/phone/CallHistory.vue
@@ -1,12 +1,14 @@
 <template>
   <div>
-    <div class="flex flex-row justify-between">
-      <th>Phone Number</th>
-      <th>Case #</th>
-      <th>Call Status</th>
-      <th>Notes</th>
-      <th>Call Completed</th>
-    </div>
+    <table>
+      <tr>
+        <th>Phone Number</th>
+        <th>Case #</th>
+        <th>Call Status</th>
+        <th>Notes</th>
+        <th>Call Completed</th>
+      </tr>
+    </table>
     <call-summary
       v-for="(detail, idx) in details"
       :key="idx"
@@ -37,3 +39,9 @@ export default {
   },
 };
 </script>
+
+<style scoped>
+.table {
+  display: grid;
+}
+</style>

--- a/src/components/phone/CallHistory.vue
+++ b/src/components/phone/CallHistory.vue
@@ -2,11 +2,51 @@
   <div>
     <table>
       <tr>
-        <th>Phone Number</th>
-        <th>Case #</th>
-        <th>Call Status</th>
-        <th>Notes</th>
-        <th>Call Completed</th>
+        <th>
+          <base-text
+            variant="bodysm"
+            weight="900"
+            class="text-crisiscleanup-dark-300"
+          >
+            Phone Number
+          </base-text>
+        </th>
+        <th>
+          <base-text
+            variant="bodysm"
+            weight="900"
+            class="text-crisiscleanup-dark-300"
+          >
+            Case #
+          </base-text>
+        </th>
+        <th>
+          <base-text
+            variant="bodysm"
+            weight="900"
+            class="text-crisiscleanup-dark-300"
+          >
+            Call Status
+          </base-text>
+        </th>
+        <th>
+          <base-text
+            variant="bodysm"
+            weight="900"
+            class="text-crisiscleanup-dark-300"
+          >
+            Notes
+          </base-text>
+        </th>
+        <th>
+          <base-text
+            variant="bodysm"
+            weight="900"
+            class="text-crisiscleanup-dark-300"
+          >
+            Call Completed
+          </base-text>
+        </th>
       </tr>
     </table>
     <call-summary
@@ -43,5 +83,17 @@ export default {
 <style scoped>
 .table {
   display: grid;
+  grid-template-columns: minmax(150px, 1.33fr) minmax(150px, 2.33fr);
+}
+th {
+  position: sticky;
+  top: 0;
+  text-align: left;
+  font-weight: normal;
+  position: relative;
+  padding: 5px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 </style>

--- a/src/components/phone/CallHistory.vue
+++ b/src/components/phone/CallHistory.vue
@@ -83,15 +83,28 @@ export default {
 <style scoped>
 .table {
   display: grid;
-  grid-template-columns: minmax(150px, 1.33fr) minmax(150px, 2.33fr);
+  min-width: 100vw;
+  width: auto;
+  flex: 1;
+  border-collapse: collapse;
+  grid-template-columns:
+    minmax(150px, 3.33fr)
+    minmax(150px, 1.67fr)
+    minmax(150px, 1.67fr)
+    minmax(150px, 3.33fr)
+    minmax(150px, 1fr);
 }
 th {
-  position: sticky;
+  /* position: sticky;
   top: 0;
   text-align: left;
   font-weight: normal;
   position: relative;
-  padding: 5px;
+  padding: 15px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap; */
+  padding: 15px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/src/components/phone/CallHistory.vue
+++ b/src/components/phone/CallHistory.vue
@@ -1,56 +1,46 @@
 <template>
   <div>
-    <table>
-      <thead>
-        <tr>
-          <th>
-            <base-text
-              variant="bodysm"
-              weight="900"
-              class="text-crisiscleanup-dark-300"
-            >
-              Phone Number
-            </base-text>
-          </th>
-          <th>
-            <base-text
-              variant="bodysm"
-              weight="900"
-              class="text-crisiscleanup-dark-300"
-            >
-              Case #
-            </base-text>
-          </th>
-          <th>
-            <base-text
-              variant="bodysm"
-              weight="900"
-              class="text-crisiscleanup-dark-300"
-            >
-              Call Status
-            </base-text>
-          </th>
-          <th>
-            <base-text
-              variant="bodysm"
-              weight="900"
-              class="text-crisiscleanup-dark-300"
-            >
-              Notes
-            </base-text>
-          </th>
-          <th>
-            <base-text
-              variant="bodysm"
-              weight="900"
-              class="text-crisiscleanup-dark-300"
-            >
-              Call Completed
-            </base-text>
-          </th>
-        </tr>
-      </thead>
-    </table>
+    <div class="wrapper">
+      <base-text
+        variant="bodysm"
+        weight="900"
+        class="text-crisiscleanup-dark-300"
+      >
+        Phone Number
+      </base-text>
+
+      <base-text
+        variant="bodysm"
+        weight="900"
+        class="text-crisiscleanup-dark-300"
+      >
+        Case #
+      </base-text>
+
+      <base-text
+        variant="bodysm"
+        weight="900"
+        class="text-crisiscleanup-dark-300"
+      >
+        Call Status
+      </base-text>
+
+      <base-text
+        variant="bodysm"
+        weight="900"
+        class="text-crisiscleanup-dark-300"
+      >
+        Notes
+      </base-text>
+
+      <base-text
+        variant="bodysm"
+        weight="900"
+        class="text-crisiscleanup-dark-300"
+      >
+        Call Completed
+      </base-text>
+    </div>
     <call-summary
       v-for="(detail, idx) in details"
       :key="idx"
@@ -83,36 +73,14 @@ export default {
 </script>
 
 <style scoped>
-.table {
+.wrapper {
   display: grid;
-  min-width: 100vw;
-  width: auto;
-  flex: 1;
-  border-collapse: collapse;
-  grid-template-columns:
-    minmax(150px, 5.44fr)
-    minmax(150px, 1.67fr)
-    minmax(150px, 1.67fr)
-    minmax(150px, 3.33fr)
-    minmax(150px, 1fr);
+  grid-template-columns: repeat(6, minmax(50px, 1fr));
+  max-width: 800px;
 }
-thead,
-tr {
-  display: contents;
-}
-th {
-  /* position: sticky;
-  top: 0;
-  text-align: left;
-  font-weight: normal;
-  position: relative;
-  padding: 15px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap; */
-  padding: 15px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+.row {
+  grid-column: auto;
+  display: grid;
+  grid-template-columns: repeat(6, minmax(50px, 1fr));
 }
 </style>

--- a/src/components/phone/CallHistory.vue
+++ b/src/components/phone/CallHistory.vue
@@ -78,7 +78,7 @@ export default {
 .wrapper {
   display: grid;
   grid-template-columns: repeat(6, minmax(50px, 1fr));
-  max-width: 800px;
+  max-width: auto;
 }
 .row {
   grid-column: auto;

--- a/src/components/phone/CallSummary.vue
+++ b/src/components/phone/CallSummary.vue
@@ -49,17 +49,16 @@ export default {
 .wrapper {
   display: grid;
   grid-template-columns: repeat(6, minmax(50px, 1fr));
-  max-width: 800px;
+  /* max-width: 800px; */
+  min-width: 700px;
 }
 .row {
-  grid-column: auto;
+  grid-column: 1 / -1;
   display: grid;
   grid-template-columns: repeat(6, minmax(50px, 1fr));
 }
-
-/* .box {
-   border-radius: 5px;
-   padding: 20px;
-   font-size: 150%;
-} */
+.box {
+  border-radius: 5px;
+  padding: 5px;
+}
 </style>

--- a/src/components/phone/CallSummary.vue
+++ b/src/components/phone/CallSummary.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="attribute-container part-id">
+  <div>
     <table>
       <tr>
         <td>

--- a/src/components/phone/CallSummary.vue
+++ b/src/components/phone/CallSummary.vue
@@ -62,21 +62,4 @@ td {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-/* .atttribute-container {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(var(--column-width-min), 1fr));
-}
-.part-id {
-  --column-width-min: 10em;
-}
-.attribute {
-  display: grid;
-  grid-template-columns: minmax(9em, 30%) 1fr;
-}
-.attribute::before {
-  content: attr(data-name);
-}
-.collection-container > li:first-child {
-  display: none;
-} */
 </style>

--- a/src/components/phone/CallSummary.vue
+++ b/src/components/phone/CallSummary.vue
@@ -1,0 +1,9 @@
+<template>
+  <div></div>
+</template>
+
+<script>
+export default {
+  name: 'CallSummary',
+};
+</script>

--- a/src/components/phone/CallSummary.vue
+++ b/src/components/phone/CallSummary.vue
@@ -2,32 +2,32 @@
   <div class="attribute-container part-id">
     <table>
       <tr>
-        <th>
+        <td>
           <!-- {{ phone }} -->
           <base-text variant="bodysm" weight="300">601-123-4567</base-text>
-        </th>
-        <th>
+        </td>
+        <td>
           <!-- {{ name }} -->
           <base-text variant="bodysm" weight="300">Julie Smith</base-text>
-        </th>
-        <th>
+        </td>
+        <td>
           <!-- {{ caseNumber }} -->
           <base-text variant="bodysm" weight="300">C11</base-text>
-        </th>
-        <th>
+        </td>
+        <td>
           <!-- {{ callStatus }} -->
           <base-text variant="bodysm" weight="300">Call Status</base-text>
-        </th>
-        <th>
+        </td>
+        <td>
           <!-- {{ notes }} -->
           <base-text variant="bodysm" weight="300"
             >Lorem ipsum adshnasdsoih alsdfgnx ad aldsk asdiigh</base-text
           >
-        </th>
-        <th>
+        </td>
+        <td>
           <!-- {{ callCompleted }} -->
           <base-text variant="bodysm" weight="300">10 mins ago</base-text>
-        </th>
+        </td>
       </tr>
     </table>
   </div>
@@ -42,6 +42,25 @@ export default {
 <style scoped>
 .table {
   display: grid;
+  min-width: 100vw;
+  width: auto;
+  flex: 1;
+  border-collapse: collapse;
+  grid-template-columns:
+    minmax(150px, 3.33fr)
+    minmax(150px, 1.67fr)
+    minmax(150px, 1.67fr)
+    minmax(150px, 3.33fr)
+    minmax(150px, 1fr);
+}
+tr {
+  display: contents;
+}
+td {
+  padding: 15px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 /* .atttribute-container {
   display: grid;

--- a/src/components/phone/CallSummary.vue
+++ b/src/components/phone/CallSummary.vue
@@ -1,33 +1,35 @@
 <template>
-  <div>
-    <div class="flex flex-row justify-between">
-      <th>
-        <!-- {{ phone }} -->
-        <base-text variant="bodysm" weight="300">601-123-4567</base-text>
-      </th>
-      <th>
-        <!-- {{ name }} -->
-        <base-text variant="bodysm" weight="300">Julie Smith</base-text>
-      </th>
-      <th>
-        <!-- {{ caseNumber }} -->
-        <base-text variant="bodysm" weight="300">C11</base-text>
-      </th>
-      <th>
-        <!-- {{ callStatus }} -->
-        <base-text variant="bodysm" weight="300">Call Status</base-text>
-      </th>
-      <th>
-        <!-- {{ notes }} -->
-        <base-text variant="bodysm" weight="300"
-          >Lorem ipsum adshnasdsoih alsdfgnx ad aldsk asdiigh</base-text
-        >
-      </th>
-      <th>
-        <!-- {{ callCompleted }} -->
-        <base-text variant="bodysm" weight="300">10 mins ago</base-text>
-      </th>
-    </div>
+  <div class="attribute-container part-id">
+    <table>
+      <tr>
+        <th>
+          <!-- {{ phone }} -->
+          <base-text variant="bodysm" weight="300">601-123-4567</base-text>
+        </th>
+        <th>
+          <!-- {{ name }} -->
+          <base-text variant="bodysm" weight="300">Julie Smith</base-text>
+        </th>
+        <th>
+          <!-- {{ caseNumber }} -->
+          <base-text variant="bodysm" weight="300">C11</base-text>
+        </th>
+        <th>
+          <!-- {{ callStatus }} -->
+          <base-text variant="bodysm" weight="300">Call Status</base-text>
+        </th>
+        <th>
+          <!-- {{ notes }} -->
+          <base-text variant="bodysm" weight="300"
+            >Lorem ipsum adshnasdsoih alsdfgnx ad aldsk asdiigh</base-text
+          >
+        </th>
+        <th>
+          <!-- {{ callCompleted }} -->
+          <base-text variant="bodysm" weight="300">10 mins ago</base-text>
+        </th>
+      </tr>
+    </table>
   </div>
 </template>
 
@@ -36,3 +38,26 @@ export default {
   name: 'CallSummary',
 };
 </script>
+
+<style scoped>
+.table {
+  display: grid;
+}
+/* .atttribute-container {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(var(--column-width-min), 1fr));
+}
+.part-id {
+  --column-width-min: 10em;
+}
+.attribute {
+  display: grid;
+  grid-template-columns: minmax(9em, 30%) 1fr;
+}
+.attribute::before {
+  content: attr(data-name);
+}
+.collection-container > li:first-child {
+  display: none;
+} */
+</style>

--- a/src/components/phone/CallSummary.vue
+++ b/src/components/phone/CallSummary.vue
@@ -20,13 +20,21 @@
         </td>
         <td>
           <!-- {{ notes }} -->
-          <base-text variant="bodysm" weight="300"
+          <base-text
+            variant="bodysm"
+            weight="300"
+            class="text-crisiscleanup-dark-300"
             >Lorem ipsum adshnasdsoih alsdfgnx ad aldsk asdiigh</base-text
           >
         </td>
         <td>
           <!-- {{ callCompleted }} -->
-          <base-text variant="bodysm" weight="300">10 mins ago</base-text>
+          <base-text
+            variant="bodysm"
+            weight="300"
+            class="text-crisiscleanup-dark-300"
+            >10 mins ago</base-text
+          >
         </td>
       </tr>
     </table>

--- a/src/components/phone/CallSummary.vue
+++ b/src/components/phone/CallSummary.vue
@@ -1,43 +1,41 @@
 <template>
   <div>
-    <table>
-      <tr>
-        <td>
-          <!-- {{ phone }} -->
-          <base-text variant="bodysm" weight="300">601-123-4567</base-text>
-        </td>
-        <td>
-          <!-- {{ name }} -->
-          <base-text variant="bodysm" weight="300">Julie Smith</base-text>
-        </td>
-        <td>
-          <!-- {{ caseNumber }} -->
-          <base-text variant="bodysm" weight="300">C11</base-text>
-        </td>
-        <td>
-          <!-- {{ callStatus }} -->
-          <base-text variant="bodysm" weight="300">Call Status</base-text>
-        </td>
-        <td>
-          <!-- {{ notes }} -->
-          <base-text
-            variant="bodysm"
-            weight="300"
-            class="text-crisiscleanup-dark-300"
-            >Lorem ipsum adshnasdsoih alsdfgnx ad aldsk asdiigh</base-text
-          >
-        </td>
-        <td>
-          <!-- {{ callCompleted }} -->
-          <base-text
-            variant="bodysm"
-            weight="300"
-            class="text-crisiscleanup-dark-300"
-            >10 mins ago</base-text
-          >
-        </td>
-      </tr>
-    </table>
+    <div class="wrapper">
+      <div class="box a">
+        <!-- {{ phone }} -->
+        <base-text variant="bodysm" weight="300">601-123-4567</base-text>
+      </div>
+      <div class="box b">
+        <!-- {{ name }} -->
+        <base-text variant="bodysm" weight="300">Julie Smith</base-text>
+      </div>
+      <div class="box c">
+        <!-- {{ caseNumber }} -->
+        <base-text variant="bodysm" weight="300">C11</base-text>
+      </div>
+      <div class="box d">
+        <!-- {{ callStatus }} -->
+        <base-text variant="bodysm" weight="300">Call Status</base-text>
+      </div>
+      <div class="box e">
+        <!-- {{ notes }} -->
+        <base-text
+          variant="bodysm"
+          weight="300"
+          class="text-crisiscleanup-dark-300"
+          >Lorem ipsum adshnasdsoih alsdfgnx ad aldsk asdiigh</base-text
+        >
+      </div>
+      <div class="box f">
+        <!-- {{ callCompleted }} -->
+        <base-text
+          variant="bodysm"
+          weight="300"
+          class="text-crisiscleanup-dark-300"
+          >10 mins ago</base-text
+        >
+      </div>
+    </div>
   </div>
 </template>
 
@@ -48,26 +46,20 @@ export default {
 </script>
 
 <style scoped>
-.table {
+.wrapper {
   display: grid;
-  min-width: 100vw;
-  width: auto;
-  flex: 1;
-  border-collapse: collapse;
-  grid-template-columns:
-    minmax(150px, 3.33fr)
-    minmax(150px, 1.67fr)
-    minmax(150px, 1.67fr)
-    minmax(150px, 3.33fr)
-    minmax(150px, 1fr);
+  grid-template-columns: repeat(6, minmax(50px, 1fr));
+  max-width: 800px;
 }
-tr {
-  display: contents;
+.row {
+  grid-column: auto;
+  display: grid;
+  grid-template-columns: repeat(6, minmax(50px, 1fr));
 }
-td {
-  padding: 15px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
+
+/* .box {
+   border-radius: 5px;
+   padding: 20px;
+   font-size: 150%;
+} */
 </style>

--- a/src/components/phone/CallSummary.vue
+++ b/src/components/phone/CallSummary.vue
@@ -1,5 +1,34 @@
 <template>
-  <div></div>
+  <div>
+    <div class="flex flex-row justify-between">
+      <th>
+        <!-- {{ phone }} -->
+        <base-text variant="bodysm" weight="300">601-123-4567</base-text>
+      </th>
+      <th>
+        <!-- {{ name }} -->
+        <base-text variant="bodysm" weight="300">Julie Smith</base-text>
+      </th>
+      <th>
+        <!-- {{ caseNumber }} -->
+        <base-text variant="bodysm" weight="300">C11</base-text>
+      </th>
+      <th>
+        <!-- {{ callStatus }} -->
+        <base-text variant="bodysm" weight="300">Call Status</base-text>
+      </th>
+      <th>
+        <!-- {{ notes }} -->
+        <base-text variant="bodysm" weight="300"
+          >Lorem ipsum adshnasdsoih alsdfgnx ad aldsk asdiigh</base-text
+        >
+      </th>
+      <th>
+        <!-- {{ callCompleted }} -->
+        <base-text variant="bodysm" weight="300">10 mins ago</base-text>
+      </th>
+    </div>
+  </div>
 </template>
 
 <script>

--- a/src/components/phone/PeopleStoriesCard.vue
+++ b/src/components/phone/PeopleStoriesCard.vue
@@ -43,3 +43,17 @@ export default {
   },
 };
 </script>
+
+<style scoped>
+/* tab selection colors */
+.tab-btn {
+  padding: 6px 10px;
+  cursor: pointer;
+  margin-bottom: 1rem;
+  border: 2px;
+  outline: none;
+}
+.active {
+  border-bottom: 3px solid #ffb92f;
+}
+</style>

--- a/src/components/phone/PeopleStoriesCard.vue
+++ b/src/components/phone/PeopleStoriesCard.vue
@@ -19,26 +19,29 @@
     </base-text>
     <!-- line -->
     <hr class="bg-white" />
-    <!-- Individual Stories Card -->
+    <!-- Individual Stories Tab -->
     <div class="stories">
       <i-story />
       <i-story />
     </div>
+    <!-- Call History Tab -->
+    <call-history />
   </div>
 </template>
 
 <script>
+import CallHistory from '@/components/phone/CallHistory.vue';
 import IndividualStoriesCard from './IndividualStoriesCard.vue';
 export default {
   name: 'PeopleStoriesCard',
   components: {
     'i-story': IndividualStoriesCard,
+    CallHistory,
   },
   data() {
     return {
       tabs: ['Stories from people you helped', 'Last 10 people I talk to'],
-      selected: 'Training',
-      isShowingTrainingModal: false,
+      selected: 'Stories from people you helped',
     };
   },
 };

--- a/src/components/phone/PeopleStoriesCard.vue
+++ b/src/components/phone/PeopleStoriesCard.vue
@@ -10,19 +10,12 @@
     >
       {{ tab }}
     </button>
-    <!-- Header -->
-    <base-text
-      variant="h3"
-      class="text-crisiscleanup-dark-400 justify-between font-bold m-1 p-3"
-    >
-      Stories from people you helped
-    </base-text>
-    <!-- line -->
-    <hr class="bg-white" />
+    <component :is="selected" class="tab"></component>
     <!-- Individual Stories Tab -->
     <div class="stories">
-      <i-story />
-      <i-story />
+      <hr class="bg-white" />
+      <IndividualStoriesCard />
+      <IndividualStoriesCard />
     </div>
     <!-- Call History Tab -->
     <call-history />
@@ -35,8 +28,8 @@ import IndividualStoriesCard from './IndividualStoriesCard.vue';
 export default {
   name: 'PeopleStoriesCard',
   components: {
-    'i-story': IndividualStoriesCard,
-    CallHistory,
+    'Stories from people you helped': IndividualStoriesCard,
+    'Last 10 people I talk to': CallHistory,
   },
   data() {
     return {

--- a/src/components/phone/PeopleStoriesCard.vue
+++ b/src/components/phone/PeopleStoriesCard.vue
@@ -1,5 +1,15 @@
 <template>
   <div class="bg-white shadow-crisiscleanup-card">
+    <!--- Tabs --->
+    <button
+      v-for="tab in tabs"
+      :key="tab"
+      @click="selected = tab"
+      :class="['tab-btn', { active: selected === tab }]"
+      class="m-1"
+    >
+      {{ tab }}
+    </button>
     <!-- Header -->
     <base-text
       variant="h3"
@@ -23,6 +33,13 @@ export default {
   name: 'PeopleStoriesCard',
   components: {
     'i-story': IndividualStoriesCard,
+  },
+  data() {
+    return {
+      tabs: ['Stories from people you helped', 'Last 10 people I talk to'],
+      selected: 'Training',
+      isShowingTrainingModal: false,
+    };
   },
 };
 </script>

--- a/src/pages/phone/Dashboard.vue
+++ b/src/pages/phone/Dashboard.vue
@@ -23,6 +23,7 @@
                 <Table :columns="contactsCols" :data="contactMetrics" />
               </div>
             </div>
+            <PeopleStoriesCard class="w-full" />
           </div>
         </template>
       </phone-layout>
@@ -39,6 +40,7 @@ import Leaderboard from '@/components/phone/Leaderboard.vue';
 import PhoneLayout from '@/layouts/Phone.vue';
 import AgentBlock from '@/components/phone/blocks/Agent.vue';
 import Table from '@/components/Table.vue';
+import PeopleStoriesCard from '@/components/phone/PeopleStoriesCard.vue';
 
 export default {
   name: 'Phone',
@@ -50,6 +52,7 @@ export default {
 
     'training-card': NewsTrainingCard,
     Leaderboard,
+    PeopleStoriesCard,
   },
   data() {
     return {

--- a/src/pages/phone/Dashboard.vue
+++ b/src/pages/phone/Dashboard.vue
@@ -20,9 +20,14 @@
                   :time-to-complete="training.timeToComplete"
                 >
                 </training-card>
-                <Table :columns="contactsCols" :data="contactMetrics" />
+                <Stories />
               </div>
             </div>
+          </div>
+        </template>
+        <template #grid-end>
+          <div class="grid--end">
+            <Table :columns="contactsCols" :data="contactMetrics" />
           </div>
         </template>
       </phone-layout>
@@ -39,7 +44,7 @@ import Leaderboard from '@/components/phone/Leaderboard.vue';
 import PhoneLayout from '@/layouts/Phone.vue';
 import AgentBlock from '@/components/phone/blocks/Agent.vue';
 import Table from '@/components/Table.vue';
-import PeopleStoriesCard from '@/components/phone/PeopleStoriesCard.vue';
+import Stories from '@/components/phone/PeopleStoriesCard.vue';
 
 export default {
   name: 'Phone',
@@ -48,7 +53,7 @@ export default {
     AgentBlock,
     Loader,
     Table,
-
+    Stories,
     'training-card': NewsTrainingCard,
     Leaderboard,
   },

--- a/src/pages/phone/Dashboard.vue
+++ b/src/pages/phone/Dashboard.vue
@@ -23,6 +23,7 @@
                 <Table :columns="contactsCols" :data="contactMetrics" />
               </div>
             </div>
+            <PeopleStoriesCard class="w-auto" />
           </div>
         </template>
       </phone-layout>
@@ -51,6 +52,7 @@ export default {
 
     'training-card': NewsTrainingCard,
     Leaderboard,
+    PeopleStoriesCard,
   },
   data() {
     return {

--- a/src/pages/phone/Dashboard.vue
+++ b/src/pages/phone/Dashboard.vue
@@ -23,7 +23,6 @@
                 <Table :columns="contactsCols" :data="contactMetrics" />
               </div>
             </div>
-            <PeopleStoriesCard class="w-auto" />
           </div>
         </template>
       </phone-layout>
@@ -52,7 +51,6 @@ export default {
 
     'training-card': NewsTrainingCard,
     Leaderboard,
-    PeopleStoriesCard,
   },
   data() {
     return {

--- a/src/pages/phone/Dashboard.vue
+++ b/src/pages/phone/Dashboard.vue
@@ -23,7 +23,6 @@
                 <Table :columns="contactsCols" :data="contactMetrics" />
               </div>
             </div>
-            <PeopleStoriesCard class="w-full" />
           </div>
         </template>
       </phone-layout>
@@ -52,7 +51,6 @@ export default {
 
     'training-card': NewsTrainingCard,
     Leaderboard,
-    PeopleStoriesCard,
   },
   data() {
     return {


### PR DESCRIPTION
Issue #618 
- added tabs to "PeopleStoriesCard.vue"
- added tab styling
- created "CallHistory.vue" to components/phone dir
        - imported into PeopleStoriesCard.vue
        - added column headers
        - added computed placeholder data (commented out)
        - added space in header between phone # & case #
- created "CallSummary.vue" to components/phone dir
        - imported into CallHistory.vue
        - Added Placeholder information
        - added mustache data (commented out)
- made tabs work properly
- converted from flex to CSS Grid Table
          - added css grid elements
          - added column sizing via CSS grid-template-columns
          - fixed CallSummary.vue sizing
          - added grid-template-columns
          - reformatted from ol to table with CSS Grids
- added basetext
- fixed header font, color & weight
- added css grid elements
- fixed text colors
- coverted from Table -> Div Wrapper container
          - deleted all table elements & css
          - added div "wrapper" class w/ CSS
          - put each column element within a "box" div class
          - added "box" & "row" css
- fixed sizing & margins
- deleted unnecessary CSS/comments, unnecessary stories header & content