### PR TITLE
User: when updating user state, save model instance before API call

### DIFF
--- a/src/models/User.js
+++ b/src/models/User.js
@@ -147,14 +147,15 @@ export default class User extends Model {
       },
       async updateUserState(states, reload = false) {
         const currentUser = User.find(AuthService.getUser().user_claims.id);
-        const newStates = {
+        currentUser.states = {
           ...currentUser.states,
           ...states,
         };
+        currentUser.$save();
         await this.patch(
           `/users/${currentUser.id}`,
           {
-            states: newStates,
+            states: currentUser.states,
           },
           { save: false },
         );


### PR DESCRIPTION
This ensures the local copy is kept up-to-date for its next use, e.g. on the next call to the same function.

Part of https://github.com/CrisisCleanup/crisiscleanup-3-web/issues/676