### PR TITLE
feat: UI Store and Site-wide Banner

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,10 @@
 <template>
   <div id="app">
+    <BannerOverlay
+      :enabled="currentBanner.enabled"
+      :type="currentBanner.type"
+      :text="currentBanner.text"
+    />
     <component :is="layout">
       <router-view v-if="$route.meta.id !== 'caller'" />
       <PhoneLegacy
@@ -22,20 +27,23 @@
 import { mapActions, mapGetters, mapMutations } from 'vuex';
 import CCP from '@/components/phone/CCP.vue';
 import Version from '@/components/Version.vue';
+import BannerOverlay from '@/components/notifications/BannerOverlay';
 import { hash } from '@/utils/promise';
 import PhoneLegacy from './pages/phone_legacy/Index';
 
 const defaultLayout = 'authenticated';
 export default {
   name: 'App',
-  components: { PhoneLegacy, CCP, Version },
+  components: { PhoneLegacy, CCP, Version, BannerOverlay },
   computed: {
+    ...mapGetters('ui', ['currentBanner']),
     layout() {
       return `${this.$route.meta.layout || defaultLayout}-layout`;
     },
   },
   methods: {
     ...mapActions('auth', ['login', 'logout']),
+    ...mapActions('ui', ['validateBrowser']),
     ...mapGetters('auth', ['isLoggedIn']),
     ...mapMutations('enums', ['setStatuses', 'setWorkTypes']),
     async getEnums() {
@@ -62,6 +70,7 @@ export default {
     },
   },
   async mounted() {
+    await this.validateBrowser();
     await this.getEnums();
   },
 };

--- a/src/components/BaseIcon.vue
+++ b/src/components/BaseIcon.vue
@@ -88,6 +88,7 @@ export default {
     size: VueTypes.oneOf(ICON_SIZES).def('large'),
     selector: VueTypes.string,
     withText: VueTypes.bool.def(false),
+    invertColor: VueTypes.bool.def(false),
   },
   data() {
     return {
@@ -102,6 +103,7 @@ export default {
         xxs: this.size === 'xxs',
         xl: this.size === 'xl',
         text: this.withText === true,
+        inverted: this.invertColor === true,
       },
     };
   },
@@ -138,6 +140,10 @@ export default {
 .ccu-icon.xxs {
   height: 7px;
   width: 7px;
+}
+
+.ccu-icon.inverted {
+  filter: brightness(0) invert(1);
 }
 
 .base-icon.with-text p {

--- a/src/components/notifications/BannerOverlay.vue
+++ b/src/components/notifications/BannerOverlay.vue
@@ -1,0 +1,97 @@
+<template>
+  <transition name="slide-fade" appear>
+    <div v-if="enabled" :class="`banner--container ${bannerType}`">
+      <div class="banner--inner">
+        <base-text variant="h2">
+          {{ $t(text) }}
+        </base-text>
+        <ccu-icon
+          @click.native="dismissBanner"
+          :type="icons.cancel"
+          :invert-color="true"
+          size="sm"
+        />
+      </div>
+    </div>
+  </transition>
+</template>
+
+<script>
+import VueTypes from 'vue-types';
+import { mapActions } from 'vuex';
+import { IconsMixin } from '@/mixins';
+
+export default {
+  name: 'BannerOverlay',
+  mixins: [IconsMixin],
+  props: {
+    type: VueTypes.oneOf(['ERROR', 'INFO', 'WARN', 'SUCCESS']),
+    text: VueTypes.string.def('Banner Message'),
+    enabled: VueTypes.bool.def(false),
+  },
+  computed: {
+    bannerType() {
+      return this.type.toLowerCase();
+    },
+  },
+  methods: {
+    ...mapActions('ui', ['dismissBanner']),
+  },
+};
+</script>
+
+<style scoped lang="scss">
+$banner-colors: (
+  'error': 'red.300',
+  'info': 'dark-blue',
+  'warn': 'yellow.900',
+  'success': 'green.300',
+);
+
+.banner {
+  &--container {
+    @apply shadow;
+    z-index: 9999;
+    position: absolute;
+    top: 0;
+    height: 3rem;
+    width: 100vw;
+    display: flex;
+    align-items: center;
+    @each $state, $color in $banner-colors {
+      &.#{$state} {
+        background-color: theme('colors.crisiscleanup-#{$color}');
+      }
+    }
+  }
+  &--inner {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-grow: 1;
+    @apply px-12;
+
+    img.ccu-icon {
+      cursor: pointer;
+    }
+
+    p {
+      @apply text-white;
+    }
+  }
+}
+
+.slide-fade {
+  &-enter-active {
+    transition: all 0.3s ease;
+  }
+  &-leave-active {
+    transition: all 0.3s ease;
+  }
+  &-enter,
+  &-leave-to {
+    transform: translateY(-3rem);
+    opacity: 0;
+  }
+}
+</style>

--- a/src/store/__tests__/ui.tests.js
+++ b/src/store/__tests__/ui.tests.js
@@ -1,0 +1,2 @@
+import { actions } from '../modules/ui/ui.js'
+

--- a/src/store/__tests__/ui.tests.js
+++ b/src/store/__tests__/ui.tests.js
@@ -1,2 +1,25 @@
-import { actions } from '../modules/ui/ui.js'
+import getters from '../modules/ui/getters';
 
+describe('ui store', () => {
+  it('Detects Internet Explorer with IE User Agent', () => {
+    const ieUserAgent =
+      'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; .NET CLR 1.1.4322)';
+    const state = {
+      browser: {
+        userAgent: ieUserAgent,
+      },
+    };
+    expect(getters.isBrowserIE(state)).toBeTruthy();
+  });
+
+  it('Does not detect Internet Explorer with Chrome User Agent', () => {
+    const chromeUserAgent =
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36';
+    const state = {
+      browser: {
+        userAgent: chromeUserAgent,
+      },
+    };
+    expect(getters.isBrowserIE(state)).toBeFalsy();
+  });
+});

--- a/src/store/__tests__/ui.tests.js
+++ b/src/store/__tests__/ui.tests.js
@@ -27,10 +27,13 @@ describe('ui store', () => {
   it('validateBrowser shows banner in IE', async () => {
     const commit = jest.fn();
     const state = {};
-    const getters = {
-      isBrowserIE: jest.fn(() => true),
-    };
-    await actions.validateBrowser({ commit, state, getters });
+    await actions.validateBrowser({
+      commit,
+      state,
+      getters: {
+        isBrowserIE: jest.fn(() => true),
+      },
+    });
     expect(commit.mock.calls).toMatchInlineSnapshot(`
       Array [
         Array [
@@ -38,7 +41,7 @@ describe('ui store', () => {
           Object {
             "enabled": true,
             "text": "~~This website does not support Internet Explorer. We recommend using a modern browser such as Firefox, Chrome, Edge, etc.",
-            "type": "error",
+            "type": "ERROR",
           },
         ],
       ]
@@ -48,11 +51,12 @@ describe('ui store', () => {
   it('validateBrowser does not show banner outside IE', async () => {
     const commit = jest.fn();
     const state = {};
-    const getters = {
-      isBrowserIE: jest.fn(() => false),
-    };
-    await actions.validateBrowser({ commit, state, getters });
-    expect(commit.mocks.calls.length).toBe(0);
+    await actions.validateBrowser({
+      commit,
+      state,
+      getters: { isBrowserIE: false },
+    });
+    expect(commit.mock.calls.length).toBe(0);
   });
 
   it('dismissBrowser closes banner', async () => {

--- a/src/store/__tests__/ui.tests.js
+++ b/src/store/__tests__/ui.tests.js
@@ -1,4 +1,5 @@
 import getters from '../modules/ui/getters';
+import actions from '../modules/ui/actions.js';
 
 describe('ui store', () => {
   it('Detects Internet Explorer with IE User Agent', () => {
@@ -21,5 +22,52 @@ describe('ui store', () => {
       },
     };
     expect(getters.isBrowserIE(state)).toBeFalsy();
+  });
+
+  it('validateBrowser shows banner in IE', async () => {
+    const commit = jest.fn();
+    const state = {};
+    const getters = {
+      isBrowserIE: jest.fn(() => true),
+    };
+    await actions.validateBrowser({ commit, state, getters });
+    expect(commit.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          "SET_BANNER",
+          Object {
+            "enabled": true,
+            "text": "~~This website does not support Internet Explorer. We recommend using a modern browser such as Firefox, Chrome, Edge, etc.",
+            "type": "error",
+          },
+        ],
+      ]
+    `);
+  });
+
+  it('validateBrowser does not show banner outside IE', async () => {
+    const commit = jest.fn();
+    const state = {};
+    const getters = {
+      isBrowserIE: jest.fn(() => false),
+    };
+    await actions.validateBrowser({ commit, state, getters });
+    expect(commit.mocks.calls.length).toBe(0);
+  });
+
+  it('dismissBrowser closes banner', async () => {
+    const commit = jest.fn();
+    const state = { siteBanner: { enabled: true } };
+    await actions.dismissBanner({ commit, state });
+    expect(commit.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          "SET_BANNER",
+          Object {
+            "enabled": false,
+          },
+        ],
+      ]
+    `);
   });
 });

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -14,6 +14,7 @@ import locale from './modules/locale';
 import phone from './modules/phone';
 import rc from './modules/rc';
 import socket from './modules/socket';
+import ui from './modules/ui';
 
 VuexORM.use(VuexORMAxios, {
   axios,
@@ -40,6 +41,7 @@ export default new Vuex.Store({
     rc,
     socket,
     phone_legacy,
+    ui,
   },
   plugins: [VuexORM.install(database)],
   strict: debug,

--- a/src/store/modules/ui/actions.js
+++ b/src/store/modules/ui/actions.js
@@ -1,0 +1,19 @@
+/**
+ * UI Store Actions.
+ *
+ */
+import Logger from '@/utils/log';
+import * as types from './types';
+
+const Log = Logger({
+  name: 'ui.store',
+  middlewares: [
+    (result) => {
+      result.unshift('[ui.store] ');
+      return result;
+    },
+  ],
+});
+
+
+export default {};

--- a/src/store/modules/ui/actions.js
+++ b/src/store/modules/ui/actions.js
@@ -3,6 +3,7 @@
  *
  */
 import Logger from '@/utils/log';
+import * as Sentry from '@sentry/browser';
 import * as types from './types';
 
 const Log = Logger({
@@ -15,5 +16,27 @@ const Log = Logger({
   ],
 });
 
+const validateBrowser = async ({ commit, getters: { isBrowserIE } }) => {
+  if (isBrowserIE) {
+    Log.warn('unsupported browser detected!');
+    Sentry.setExtra('site_banner', 'browser_unsupported');
+    commit(types.SET_BANNER, {
+      enabled: true,
+      text:
+        '~~This website does not support Internet Explorer. We recommend using a modern browser such as Firefox, Chrome, Edge, etc.',
+      type: types.BannerTypes.ERROR,
+    });
+  }
+};
 
-export default {};
+const dismissBanner = async ({ commit }) => {
+  Log.debug('dismissing banner!');
+  commit(types.SET_BANNER, {
+    enabled: false,
+  });
+};
+
+export default {
+  validateBrowser,
+  dismissBanner,
+};

--- a/src/store/modules/ui/getters.js
+++ b/src/store/modules/ui/getters.js
@@ -1,0 +1,11 @@
+/*
+ * UI Store Getters.
+ *
+ */
+
+const isBrowserIE = ({ browser: { userAgent } }) =>
+  userAgent.indexOf('MSIE') > -1 || userAgent.indexOf('Trident/') > -1;
+
+export default {
+  isBrowserIE,
+};

--- a/src/store/modules/ui/getters.js
+++ b/src/store/modules/ui/getters.js
@@ -6,6 +6,9 @@
 const isBrowserIE = ({ browser: { userAgent } }) =>
   userAgent.indexOf('MSIE') > -1 || userAgent.indexOf('Trident/') > -1;
 
+const currentBanner = (state) => state.siteBanner;
+
 export default {
+  currentBanner,
   isBrowserIE,
 };

--- a/src/store/modules/ui/index.js
+++ b/src/store/modules/ui/index.js
@@ -1,0 +1,33 @@
+/**
+ * UI Store Root.
+ *
+ * Handles generic UI states.
+ */
+
+import actions from './actions';
+import getters from './getters';
+import mutations from './mutations';
+import * as types from './types';
+
+const getStateDefaults = () => ({
+  browser: {
+    userAgent: navigator.userAgent,
+  },
+  siteBanner: {
+    enabled: false,
+    text: '',
+    type: types.BannerTypes.ERROR,
+  },
+});
+
+const UIState = {
+  ...getStateDefaults(),
+};
+
+export default {
+  namespaced: true,
+  state: UIState,
+  actions,
+  getters,
+  mutations,
+};

--- a/src/store/modules/ui/mutations.js
+++ b/src/store/modules/ui/mutations.js
@@ -1,0 +1,9 @@
+/**
+ * UI Store Types.
+ *
+ */
+
+import * as types from './types';
+
+export default {}
+

--- a/src/store/modules/ui/mutations.js
+++ b/src/store/modules/ui/mutations.js
@@ -5,5 +5,11 @@
 
 import * as types from './types';
 
-export default {}
-
+export default {
+  [types.SET_BANNER](state, newState) {
+    state.siteBanner = {
+      ...state.siteBanner,
+      ...newState,
+    };
+  },
+};

--- a/src/store/modules/ui/types.js
+++ b/src/store/modules/ui/types.js
@@ -4,6 +4,7 @@
  */
 
 export const BannerTypes = Object.freeze({
-  ERROR: 'error',
-})
+  ERROR: 'ERROR',
+});
 
+export const SET_BANNER = 'SET_BANNER';

--- a/src/store/modules/ui/types.js
+++ b/src/store/modules/ui/types.js
@@ -1,0 +1,9 @@
+/*
+ * UI Store Types.
+ *
+ */
+
+export const BannerTypes = Object.freeze({
+  ERROR: 'error',
+})
+


### PR DESCRIPTION
Adds a new store for managing generic UI states, such as user browser information and state for a site-wide banner.

**Changes**
* 5cef2faf - feat(ui): add BannerOverlay component, add to root component 
* 29928547 - feat(ui): add validateBrowser and dismissBanner actions 
* bdef92af - feat(icon): add invertColor prop to invert icon color 
* a82c0e57 - test(ui): add tests for validate/dismiss actions 
* 37a063a7 - test(ui): add tests for IE detection 
* 9b070fa6 - feat(ui): add getter for determining if current browser is IE 
* 5f8b0fe4 - feat(ui): add new UI store for generic UI states 



Closes #702