### PR TITLE
Split User.states into global and per-incident to allow per-incident states

### DIFF
--- a/src/components/WorksiteMap.vue
+++ b/src/components/WorksiteMap.vue
@@ -121,11 +121,11 @@ import 'leaflet-loading';
 import 'leaflet.gridlayer.googlemutant';
 import 'leaflet-pixi-overlay';
 import 'leaflet.heat';
-import User from '@/models/User';
 import { averageGeolocation, getWorksiteLayer } from '@/utils/map';
 import { colors, templates } from '@/icons/icons_templates';
 import { groupBy } from '@/utils/array';
 import Worksite from '@/models/Worksite';
+import User from '@/models/User';
 
 PixiSettings.SPRITE_MAX_TEXTURES = Math.min(
   PixiSettings.SPRITE_MAX_TEXTURES,

--- a/src/components/WorksiteMap.vue
+++ b/src/components/WorksiteMap.vue
@@ -124,6 +124,7 @@ import 'leaflet.heat';
 import { averageGeolocation, getWorksiteLayer } from '@/utils/map';
 import { colors, templates } from '@/icons/icons_templates';
 import { groupBy } from '@/utils/array';
+import { mapState } from 'vuex';
 import Worksite from '@/models/Worksite';
 import User from '@/models/User';
 
@@ -194,6 +195,7 @@ export default {
     };
   },
   computed: {
+    ...mapState('incident', ['currentIncidentId']),
     currentUser() {
       return User.find(this.$store.getters['auth/userId']);
     },
@@ -255,11 +257,12 @@ export default {
             );
           }
           const { map } = this;
-          if (this.currentUser.states && this.currentUser.states.mapViewPort) {
-            const {
-              _northEast,
-              _southWest,
-            } = this.currentUser.states.mapViewPort;
+          const states = this.currentUser.getStatesForIncident(
+            this.currentIncidentId,
+            true,
+          );
+          if (states && states.mapViewPort) {
+            const { _northEast, _southWest } = states.mapViewPort;
             this.map.fitBounds([
               [_northEast.lat, _northEast.lng],
               [_southWest.lat, _southWest.lng],

--- a/src/pages/Cases.vue
+++ b/src/pages/Cases.vue
@@ -831,17 +831,21 @@ export default {
     // }.bind(this), 100000);
   },
   async mounted() {
-    if (this.currentUser.states) {
-      if (this.currentUser.states.showingMap) {
+    const states = this.currentUser.getStatesForIncident(
+      this.currentIncidentId,
+      true,
+    );
+    if (states) {
+      if (states.showingMap) {
         this.showingMap = true;
         this.showingTable = false;
       }
-      if (this.currentUser.states.appliedFilters) {
-        this.appliedFilters = this.currentUser.states.appliedFilters;
+      if (states.appliedFilters) {
+        this.appliedFilters = states.appliedFilters;
       }
-      if (this.currentUser.states.filters) {
+      if (states.filters) {
         this.filters = {
-          ...this.currentUser.states.filters,
+          ...states.filters,
         };
       }
     }
@@ -888,14 +892,18 @@ export default {
       if (!data) {
         data = {};
       }
-      User.api().updateUserState({
-        incident: this.currentIncidentId,
-        appliedFilters: this.appliedFilters,
-        filters: this.filters,
-        showingMap: this.showingMap,
-        showingTable: this.showingTable,
-        ...data,
-      });
+      User.api().updateUserState(
+        {
+          incident: this.currentIncidentId,
+        },
+        {
+          appliedFilters: this.appliedFilters,
+          filters: this.filters,
+          showingMap: this.showingMap,
+          showingTable: this.showingTable,
+          ...data,
+        },
+      );
     },
 
     onUpdatedFilters(filters) {


### PR DESCRIPTION
Split User.states into global and per-incident; store and restore using both, backwards-compatibly.

Also fixes earlier bug of incorrectly modifying Vuex store.

Supersedes https://github.com/CrisisCleanup/crisiscleanup-3-web/pull/693 and resolves https://github.com/CrisisCleanup/crisiscleanup-3-web/issues/676  