### PR TITLE
fix: Phone History/Leaderboard load delay

### DIFF
--- a/src/components/phone/CCP.vue
+++ b/src/components/phone/CCP.vue
@@ -15,7 +15,7 @@ export default {
   methods: {
     ...mapActions('phone', ['initConnect', 'setPopup']),
     async init() {
-      if (!this.connectRunning) {
+      if (!this.connectRunning && !connect.core.initialized) {
         this.$log.debug('CCP embed connecting...');
         const htmlEl = document.getElementById('ccp-embed');
         try {

--- a/src/mixins/agent.js
+++ b/src/mixins/agent.js
@@ -55,10 +55,6 @@ export const AgentMixin = {
       return { worksites, pdas, outboundIds };
     },
     getStateFriendlyName(value) {
-      let state = value;
-      if (value.includes('#')) {
-        [, , state] = value.split('#');
-      }
       const stateMap = {
         [CCState.ROUTABLE]: 'online',
         [CCState.PENDING_CALL]: 'connecting',
@@ -67,6 +63,13 @@ export const AgentMixin = {
         [CCState.ON_CALL]: 'talking',
         [CCState.AGENT_PENDING]: 'connecting',
       };
+      if (!value) {
+        return CCState.OFFLINE;
+      }
+      let state = value;
+      if (value.includes('#')) {
+        [, , state] = value.split('#');
+      }
       if (Object.keys(stateMap).includes(state)) {
         return stateMap[state];
       }

--- a/src/models/Worksite.js
+++ b/src/models/Worksite.js
@@ -177,6 +177,20 @@ export default class Worksite extends Model {
         });
         return worksite;
       },
+      async find_or_fetch(id, { resolve = true }) {
+        let item = await Worksite.find(id);
+        if (!item) {
+          if (resolve) {
+            item = Worksite.api().fetch(id);
+          } else {
+            const {
+              response: { data },
+            } = await Worksite.api().get(id);
+            item = data;
+          }
+        }
+        return item;
+      },
       claimWorksite(id, workTypes) {
         return this.post(
           `/worksites/${id}/claim`,

--- a/src/models/__mocks__/Worksite.js
+++ b/src/models/__mocks__/Worksite.js
@@ -12,5 +12,6 @@ export default {
   api: () => ({
     get: () => MockWorksites[0],
     fetch: () => MockWorksites[0],
+    find_or_fetch: () => MockWorksites[0],
   }),
 };

--- a/src/store/__tests__/__snapshots__/phone.tests.js.snap
+++ b/src/store/__tests__/__snapshots__/phone.tests.js.snap
@@ -3,6 +3,25 @@
 exports[`metric actions getAgentMetrics 1`] = `
 Array [
   Array [
+    "setControllerState",
+    Object {
+      "history": Object {
+        "resolvedCases": Array [],
+      },
+    },
+  ],
+  Array [
+    "setControllerState",
+    Object {
+      "history": Object {
+        "resolvedCases": Array [
+          1,
+          2,
+        ],
+      },
+    },
+  ],
+  Array [
     "setAgentMetrics",
     Object {
       "xxxx": Object {

--- a/src/store/__tests__/phone.tests.js
+++ b/src/store/__tests__/phone.tests.js
@@ -74,6 +74,11 @@ describe('metric actions', () => {
   it('getAgentMetrics', async () => {
     const commit = jest.fn();
     const state = {
+      controller: {
+        history: {
+          resolvedCases: [],
+        },
+      },
       contact: {
         attributes: {
           incidentId: 99,


### PR DESCRIPTION
Resolved the 10-30s delay when loading caller history and leaderboard. The issue got exponentially worse with each entry into caller history, as it was spamming the mess out of the api seeking duplicate worksite data :grimacing: 

Optimized how cases are resolved in the context of caller history and fixes issues causing a blank leaderboard temporarily.

- test(phone): update agent metrics tests
- fix(phone): optimize call history worksite resolution by preventing duplicate calls
- fix(phone): default leaderboard user states to offline
- fix(phone): ensure connect is not re-initialized inappropriately
