### PR TITLE
fix(phone): End contact issues, ACW fix, Case Cards, more

### DIFF
--- a/src/components/phone/AgentBoard/CallInfo.vue
+++ b/src/components/phone/AgentBoard/CallInfo.vue
@@ -83,7 +83,7 @@ import CaseCard from '@/components/cards/Case.vue';
 import { Carousel, Slide } from 'vue-carousel';
 import useEnums from '@/use/useEnums';
 import useContact from '@/use/phone/useContact';
-import { onMounted, computed } from '@vue/composition-api';
+import { onMounted } from '@vue/composition-api';
 import useController from '@/use/phone/useController';
 import useCaseCards from '@/use/worksites/useCaseCards';
 import useAgent from '@/use/phone/useAgent';
@@ -101,12 +101,8 @@ export default {
     const formatDuration = (duration) =>
       context.root.$moment.duration(duration, 'ms').format('h:mm:ss');
 
-    const { syncDuration, callState, ...contact } = useContact({ agent });
-    const cases = computed(() => [
-      ...callState.pdas.value,
-      ...callState.worksites.value,
-    ]);
-    const { caseCards } = useCaseCards({ cases, addNew: true });
+    const { syncDuration, callerCases, ...contact } = useContact({ agent });
+    const { caseCards } = useCaseCards({ cases: callerCases, addNew: true });
 
     onMounted(() => syncDuration.start());
 
@@ -127,7 +123,6 @@ export default {
       ...useEnums(),
       ...actions,
       ...getters,
-      callState,
       formatDuration,
       caseCards,
       setActiveCase,

--- a/src/components/phone/AgentBoard/CallInfo.vue
+++ b/src/components/phone/AgentBoard/CallInfo.vue
@@ -35,7 +35,7 @@
                 :type="enums.icons.phone_contact_add"
               />
               <ccu-icon
-                @click.native="() => closeContact(currentContact)"
+                @click.native="() => currentContact.disconnect()"
                 size="xl"
                 :type="enums.icons.phone_hangup"
               />
@@ -47,7 +47,7 @@
         <ccu-icon
           :type="enums.icons.phone_exit"
           size="large"
-          @click.native="() => closeContact(currentContact)"
+          @click.native="() => currentContact.disconnect()"
         />
       </div>
     </div>

--- a/src/components/phone/AgentBoard/Status.vue
+++ b/src/components/phone/AgentBoard/Status.vue
@@ -71,7 +71,7 @@ import useAgent from '@/use/phone/useAgent';
 export default {
   name: 'BoardStatus',
   props: {
-    lang: VueTypes.objectOf(VueTypes.any),
+    lang: VueTypes.any,
   },
   setup(props, context) {
     const { agent } = useAgent();
@@ -90,6 +90,7 @@ export default {
         context.root.$log.info('closing contact!');
         await actions.closeContact({ contact: currentContact.value });
       } catch (e) {
+        context.root.$log.debug(e);
         context.root.$toasted.error(context.root.$t(e.message));
       }
     };

--- a/src/components/phone/AgentCard.vue
+++ b/src/components/phone/AgentCard.vue
@@ -246,6 +246,10 @@ export default {
         @apply bg-crisiscleanup-green-300;
       }
 
+      &.connecting {
+        @apply bg-crisiscleanup-lightblue-800;
+      }
+
       &.talking {
         @apply bg-crisiscleanup-dark-blue;
       }

--- a/src/components/phone/Popup.vue
+++ b/src/components/phone/Popup.vue
@@ -80,29 +80,22 @@
 import CaseCard from '@/components/cards/Case.vue';
 import DisasterIcon from '@/components/DisasterIcon.vue';
 import useCaseCards from '@/use/worksites/useCaseCards';
-import VueTypes from 'vue-types';
-import Worksite from '@/models/Worksite';
-import Pda from '@/models/Pda';
-import { toRefs } from '@vue/composition-api';
 import useUser from '@/use/user/useUser';
-import AgentClient from '@/models/phone/AgentClient';
 import useContact from '@/use/phone/useContact';
 import useIncident from '@/use/worksites/useIncident';
 import useEnums from '@/use/useEnums';
+import useAgent from '@/use/phone/useAgent';
 
 export default {
   name: 'IncomingPopup',
   components: { CaseCard, DisasterIcon },
-  props: {
-    cases: VueTypes.arrayOf(VueTypes.oneOfType([Pda, Worksite])),
-    agent: VueTypes.oneOfType([AgentClient]),
-  },
-  setup(props) {
-    const { cases, agent } = toRefs(props);
+  setup() {
+    const { agent } = useAgent();
+    const { callerCases, ...contact } = useContact({ agent });
     return {
+      ...contact,
       ...useUser(),
-      ...useCaseCards({ cases: cases.value, addNew: false }),
-      ...useContact({ agent }),
+      ...useCaseCards({ cases: callerCases, addNew: false }),
       ...useIncident(),
       ...useEnums(),
     };

--- a/src/models/phone/AgentClient.js
+++ b/src/models/phone/AgentClient.js
@@ -12,7 +12,7 @@ import type {
   ConnectionType,
   RouteState,
 } from '@/models/phone/types';
-import Contact from '@/models/phone/Contact';
+import Contact, { ContactActions } from '@/models/phone/Contact';
 import Connection, { ConnectionStates } from '@/models/phone/Connection';
 import _ from 'lodash';
 import Logger from '@/utils/log';
@@ -154,7 +154,11 @@ export default class AgentClient extends Model {
   }
 
   get contactState(): ConnectionState | RouteState {
-    if (!_.isEmpty(this.connections)) {
+    if (
+      !_.isEmpty(this.connections) &&
+      !_.isNil(this.currentContact) &&
+      _.get(this.currentContact, 'action', null) !== ContactActions.DESTROYED
+    ) {
       const initConnection: ConnectionType = this.connections[0];
       return initConnection.state;
     }

--- a/src/models/phone/Contact.js
+++ b/src/models/phone/Contact.js
@@ -198,6 +198,18 @@ export default class Contact extends Model {
     }
   }
 
+  static afterDelete(model: Contact): void {
+    // connect will already auto-put the agent back into a routable
+    // state, but we also do it to trigger an upstream update.
+    const agentModel = Contact.store().$db().model('phone/agent');
+    const agentClient = agentModel
+      .query()
+      .withAllRecursive()
+      .find(model.agentId);
+    Log.info('forcing agent out of ACW!');
+    agentClient.toggleOnline(true);
+  }
+
   static afterUpdate(model: Contact): void {
     const connection: Connection = Connection.query()
       .where('contactId', model.contactId)

--- a/src/pages/phone/Index.vue
+++ b/src/pages/phone/Index.vue
@@ -2,7 +2,7 @@
   <Loader class="w-full h-full" :loading="loading">
     <template #content>
       <component v-if="!loading" :is="pageComponent" />
-      <IncomingPopup v-show="callPending" :cases="cases" :agent="agent" />
+      <IncomingPopup v-show="callPending" />
     </template>
   </Loader>
 </template>
@@ -27,18 +27,9 @@ export default {
   setup(props, context) {
     const { agent, loading } = useAgent();
     const controller = useController();
-    const {
-      callPending,
-      callConnected,
-      currentContact,
-      callState,
-    } = useContact({
+    const { callPending, callConnected, currentContact } = useContact({
       agent,
     });
-    const cases = computed(() => [
-      ...callState.worksites.value,
-      ...callState.pdas.value,
-    ]);
 
     const { start } = useIntervalFn(() => {
       agent.value.heartbeat().then(() => {
@@ -91,7 +82,6 @@ export default {
       callPending,
       callConnected,
       currentContact,
-      cases,
     };
   },
 };

--- a/src/store/modules/phone/controller.js
+++ b/src/store/modules/phone/controller.js
@@ -225,8 +225,6 @@ class ControllerStore extends VuexModule {
       await PhoneInbound.api().updateStatus(contact.inbound.id, callStatus);
     }
     await contact.disconnect();
-    Log.info('agent has ended session, deleting contact!');
-    await Contact.delete(contact.contactId);
     await this.setView({ page: ControllerPages.DASHBOARD });
   }
 

--- a/src/store/modules/phone/controller.js
+++ b/src/store/modules/phone/controller.js
@@ -225,6 +225,9 @@ class ControllerStore extends VuexModule {
       await PhoneInbound.api().updateStatus(contact.inbound.id, callStatus);
     }
     await contact.disconnect();
+    Log.info('agent has ended session, deleting contact!');
+    await Contact.delete(contact.contactId);
+    await this.setView({ page: ControllerPages.DASHBOARD });
   }
 
   @Mutation

--- a/src/store/modules/phone/controller.js
+++ b/src/store/modules/phone/controller.js
@@ -181,9 +181,9 @@ class ControllerStore extends VuexModule {
     this.setStatus({
       statusId: statusId || this.status.statusId,
       notes: notes || this.status.notes,
-      modified: modified
+      modified: _.filter(modified, _.negate(_.isNil))
         ? _.unionBy<CaseType>(this.status.modified, modified, 'id')
-        : this.status.modified,
+        : _.filter(this.status.modified, _.negate(_.isNil)),
     });
   }
 
@@ -204,7 +204,9 @@ class ControllerStore extends VuexModule {
     if (!this.status.statusId) {
       throw new Error('~~You must set a call Status!');
     }
-    await this.updateStatus({ modified: [this.currentCase] });
+    if (this.currentCase) {
+      await this.updateStatus({ modified: [this.currentCase] });
+    }
     const { statusId, notes } = this.status;
     const callStatus = {
       statusId,

--- a/src/use/phone/useAgentState.js
+++ b/src/use/phone/useAgentState.js
@@ -58,7 +58,9 @@ export default ({
         _agent.value.contactState,
         _stateAction[_agent.value.routeState],
       ),
-      enabled: _agent.value.isRoutable || _agent.value.isOnline === false,
+      enabled:
+        _agent.value.isConnecting === false &&
+        _agent.value.isConnected === false,
       statusText: _agent.value.isOnline
         ? _agent.value.friendlyState
         : _agent.value.state,

--- a/src/use/phone/useContact.js
+++ b/src/use/phone/useContact.js
@@ -101,6 +101,11 @@ export default ({ agent }) => {
     },
   ]);
 
+  const callerCases = computed(() => [
+    ...state.pdas.value,
+    ...state.worksites.value,
+  ]);
+
   return {
     callPending,
     callConnected,
@@ -113,5 +118,6 @@ export default ({ agent }) => {
     syncDuration,
     activeCalls,
     callDuration,
+    callerCases,
   };
 };

--- a/src/use/phone/useContact.js
+++ b/src/use/phone/useContact.js
@@ -81,7 +81,10 @@ export default ({ agent }) => {
   watch(
     () => currentContact.value,
     () => {
-      if (currentContact.value.action === ContactActions.ENDED) {
+      if (
+        currentContact.value &&
+        currentContact.value.action === ContactActions.ENDED
+      ) {
         syncDuration.stop();
       }
     },

--- a/src/use/worksites/useCaseCards.js
+++ b/src/use/worksites/useCaseCards.js
@@ -39,7 +39,10 @@ export default ({ cases, addNew }: UseCaseCardsProps) => {
             caseNumber: c.case_number ? c.case_number : `PDA-${c.id}`,
             address: c.short_address,
             state: c.state,
-            worktype: c.getWorkType ? c.getWorkType() : 'wellness_check',
+            worktype:
+              c instanceof Worksite
+                ? Worksite.getWorkType(c.work_types).work_type
+                : 'wellness_check',
             fullAddress: c.full_address,
             id: c.id,
             type: c instanceof Worksite ? Worksite.entity : Pda.entity,

--- a/src/use/worksites/useCaseCards.js
+++ b/src/use/worksites/useCaseCards.js
@@ -8,6 +8,7 @@ import { wrap } from '@/utils/wrap';
 import type { CaseType } from '@/store/modules/phone/types';
 import Pda from '@/models/Pda';
 import Worksite from '@/models/Worksite';
+import _ from 'lodash';
 
 export type UseCaseCardsProps = {|
   cases: CaseType[],
@@ -41,7 +42,11 @@ export default ({ cases, addNew }: UseCaseCardsProps) => {
             state: c.state,
             worktype:
               c instanceof Worksite
-                ? Worksite.getWorkType(c.work_types).work_type
+                ? _.get(
+                    Worksite.getWorkType(c.work_types),
+                    'work_type',
+                    'unknown',
+                  )
                 : 'wellness_check',
             fullAddress: c.full_address,
             id: c.id,


### PR DESCRIPTION
- fix(ctrl): delete contact after disconnect when ending contact
- fix(client): send new state upstream after contact deletion to exit ACW
- test(client): add test for agent ACW exit
- fix(ctrl): do not force end contact, end through lifecycle
- fix(phone): agent status indicator goes red when connecting
- fix(contact): error on contact deletion when stopping the call timer
- fix(use): correctly resolve case card work types
- fix(phone): do not end contact on hangup button, just disconnect
- fix(phone): popup case cards not displaying
- fix(client): do not use connection state if contact has been destroyed
- fix(ctrl): filter nil items from modified cases
- fix(client): could not change state when in ACW
- fix(phone): actually fix worktype icons
