### PR TITLE
Event Builder Points/Locale Keys/Override Fixes

### DIFF
--- a/src/components/forms/LocaleForm.vue
+++ b/src/components/forms/LocaleForm.vue
@@ -13,6 +13,7 @@
               size="medium"
               :value="fields[fieldKey].key"
               break-glass
+              @change="(value) => (fields[fieldKey].key = value)"
             />
             <base-input
               class="pb-3"

--- a/src/use/events/useEventPreview.js
+++ b/src/use/events/useEventPreview.js
@@ -34,7 +34,7 @@ export default () => {
   });
 
   const calcEventPoints = (inputs: EventInputMap) =>
-    _.reduce(inputs, (result, value) => result + _.get(value, 'points', 0), 0);
+    _.reduce(inputs, (result, value) => result * _.get(value, 'points', 1), 0);
 
   const updateEventKeys = (inputs: EventInputMap) => {
     const keyInputs = _.omit(inputs, ['user_badge']);

--- a/src/use/events/useEventPreview.js
+++ b/src/use/events/useEventPreview.js
@@ -34,7 +34,7 @@ export default () => {
   });
 
   const calcEventPoints = (inputs: EventInputMap) =>
-    _.reduce(inputs, (result, value) => result * _.get(value, 'points', 1), 0);
+    _.reduce(inputs, (result, value) => result * _.get(value, 'points', 1), 1);
 
   const updateEventKeys = (inputs: EventInputMap) => {
     const keyInputs = _.omit(inputs, ['user_badge']);

--- a/src/use/useSelectForm.js
+++ b/src/use/useSelectForm.js
@@ -78,6 +78,12 @@ export default <T: typeof CCUModel>({
       itemId.map(onSelected);
       return;
     }
+    if (itemId === -1) {
+      selected.value.push(itemId);
+      _value.value = multi ? selected.value : _.last(selected.value);
+      context.root.$log.debug('selected: ', itemId);
+      return;
+    }
     const _resolveFromId = resolveFromId || model.fetchOrFindId;
     const item = await _.bind(_resolveFromId, model)(itemId);
     selected.value.push(translate ? item.withTrans() : item);

--- a/src/utils/form.js
+++ b/src/utils/form.js
@@ -72,9 +72,11 @@ export const makeLocaleInputs = ({
     inputs,
     (result, value) => {
       const [name, suffix = null] = _.split(value, ':');
-      const _key = `${prefix}.${base}${
+      let _key = `${prefix}.${base}${
         _.isNil(suffix) ? '' : `_${suffix || ''}`
       }`;
+      const keyParts = _.split(_key, ':');
+      _key = keyParts.join('_');
       result[name] = {
         value,
         key: _key,


### PR DESCRIPTION
Closes #1040
Closes #1041

- fix(events): incorrect operation when calculating event points
- fix(events): accumulate onto starting value of 1, not 0
- fix(locale): handle locale key suffixes in locale form
- fix(locale): overwriting locale key name did not save
- fix(useselect): handle negative item ids for placeholder items
