### PR TITLE
Prevent Agents from exiting ACW before closing a case, Manual Outbound Fixes

### DIFF
--- a/src/components/buttons/ProgressButton.vue
+++ b/src/components/buttons/ProgressButton.vue
@@ -11,7 +11,7 @@
 
 <script>
 import VueTypes from 'vue-types';
-import { computed } from '@vue/composition-api';
+import { computed, watch, ref } from '@vue/composition-api';
 
 export default {
   name: 'ProgressButton',
@@ -20,7 +20,8 @@ export default {
     total: VueTypes.number,
     reverse: VueTypes.bool.def(false),
   },
-  setup(props) {
+  setup(props, context) {
+    const _complete = ref(false);
     const step = computed(() => {
       let base = typeof props.value === 'number' ? props.value : props.value();
       if (props.total && props.total !== 0) {
@@ -34,10 +35,22 @@ export default {
       transform: `translateX(${-step.value}%)`,
     }));
     const loadClass = computed(() => ({
-      loading: Math.abs(step.value) > 0,
+      loading: Math.abs(step.value) > 0 && Math.abs(step.value) < 100,
       reverse: props.reverse === true,
     }));
+    watch(
+      () => step.value,
+      () => {
+        if (Math.abs(step.value) >= 100 && _complete.value === false) {
+          context.emit('update:done', true);
+          _complete.value = true;
+        } else if (Math.abs(step.value) < 100 && _complete.value !== false) {
+          _complete.value = false;
+        }
+      },
+    );
     return {
+      step,
       loadStyle,
       loadClass,
     };

--- a/src/components/header/PhoneStatus.vue
+++ b/src/components/header/PhoneStatus.vue
@@ -79,7 +79,7 @@ export default {
       if (!connected.value) {
         return router.push('/phone');
       }
-      return toggleAgentState();
+      return toggleAgentState({ userInitiated: true });
     };
 
     const setStyle = () => {

--- a/src/components/phone/AgentCard.vue
+++ b/src/components/phone/AgentCard.vue
@@ -55,12 +55,13 @@
       <div class="inline-flex action-btn">
         <ProgressButton
           :alt="$t(agentState.text)"
-          :action="() => handleStateChange()"
+          :action="() => handleStateChange({ userInitiated: true })"
           :disabled="!agentState.enabled"
           :total="240"
           :value="acwDuration"
           size="large"
           variant="solid"
+          @update:done="() => handleStateChange()"
         >
           {{ $t(agentState.text) }}
         </ProgressButton>
@@ -206,7 +207,7 @@ export default {
       isTrained: true,
     });
 
-    const handleStateChange = async () => {
+    const handleStateChange = async (args) => {
       // if (!props.trainingComplete) {
       //   if (agent.value && agent.value.isOnline) {
       //     await agent.value.toggleOnline(false);
@@ -214,7 +215,7 @@ export default {
       //   context.emit('phone:showTraining', true);
       //   return;
       // }
-      await toggleAgentState();
+      await toggleAgentState(args);
     };
 
     const { currentIncident } = useIncident();

--- a/src/components/phone/AgentCard.vue
+++ b/src/components/phone/AgentCard.vue
@@ -262,6 +262,7 @@ export default {
           await ctrlStore.serveOutbound({
             agent: agent.value,
             incident: currentIncident.value,
+            manual: true,
           });
           context.root.$toasted.success(
             context.root.$t('phoneDashboard.success_calling_momentarily'),

--- a/src/models/PhoneInbound.js
+++ b/src/models/PhoneInbound.js
@@ -18,7 +18,7 @@ export default class PhoneInbound extends CCUModel {
   static apiConfig = {
     actions: {
       async skipCall(id) {
-        await this.post(`/phone_inbound/${id}/skip`, { save: false });
+        await this.post(`/phone_inbound/${id}/skip`, {}, { save: false });
       },
       async fetchById(id) {
         const inbound = await this.get(`/phone_inbound/${id}`);

--- a/src/models/PhoneOutbound.js
+++ b/src/models/PhoneOutbound.js
@@ -47,6 +47,7 @@ export default class PhoneOutbound extends CCUModel {
         incidentId = 199,
         agentId = '',
         useCalldowns = false,
+        isManual = false,
       }) {
         let queryUrl = `/phone_outbound?next=${incidentId}`;
         if (agentId) {
@@ -54,6 +55,9 @@ export default class PhoneOutbound extends CCUModel {
         }
         if (useCalldowns) {
           queryUrl = `${queryUrl}&use_calldowns=1`;
+        }
+        if (isManual) {
+          queryUrl = `${queryUrl}&manual=1`;
         }
         const phoneOutbound = await this.get(queryUrl);
         const {
@@ -77,8 +81,14 @@ export default class PhoneOutbound extends CCUModel {
         } = phoneOutbound;
         return data;
       },
-      async callOutbound(id) {
-        const result = this.post(`/phone_outbound/${id}/call`, { save: false });
+      async callOutbound(id, { isManual = false } = {}) {
+        const result = this.post(
+          `/phone_outbound/${id}/call`,
+          {
+            manual: isManual,
+          },
+          { save: false },
+        );
         return result;
       },
       async updateStatus(

--- a/src/models/phone/Contact.js
+++ b/src/models/phone/Contact.js
@@ -283,7 +283,7 @@ export default class Contact extends Model {
     Sentry.setContext(Contact.entity, model.$toJson());
   }
 
-  static beforeUpdate(model: Contact): void {
+  static beforeUpdate(model: Contact): void | boolean {
     if (
       ![
         ContactActions.DESTROYED,
@@ -296,6 +296,16 @@ export default class Contact extends Model {
     if (model.action === ContactActions.ABANDON) {
       window.vue.$toasted.error(window.vue.$t('~~Survivor ended the call!'));
     }
+    if ([ContactActions.DESTROYED].includes(model.action)) {
+      const isCallActive = Contact.store().getters[
+        'phone.controller/isCallActive'
+      ];
+      if (isCallActive) {
+        Log.info('Agent has not closed contact! Preventing ACW exit...');
+        return false;
+      }
+    }
+    return true;
   }
 
   static beforeDelete(model: Contact): void {

--- a/src/store/modules/phone/controller.js
+++ b/src/store/modules/phone/controller.js
@@ -372,10 +372,12 @@ class ControllerStore extends VuexModule {
   async serveOutbound({
     agent,
     incident,
+    manual = false,
   }: {
     agent: typeof AgentClient,
     incident: typeof Incident,
-  }) {
+    manual: boolean,
+  } = {}) {
     if (this.isServingOutbounds) {
       Log.info('attempting to serve outbound call for:', incident);
       let outbound;
@@ -384,6 +386,7 @@ class ControllerStore extends VuexModule {
           incidentId: incident.id,
           agentId: agent.agentId,
           useCalldowns: true,
+          isManual: manual,
         });
       } catch (e) {
         Log.info('no outbounds available!');
@@ -393,7 +396,9 @@ class ControllerStore extends VuexModule {
       const outboundObj = await PhoneOutbound.fetchOrFindId(outbound.id);
       this.setOutbound(outboundObj);
       try {
-        await PhoneOutbound.api().callOutbound(outbound.id);
+        await PhoneOutbound.api().callOutbound(outbound.id, {
+          isManual: manual,
+        });
         const contactId = outboundObj.external_id
           ? outboundObj.external_id
           : `${agent.agentId}#manual-outbound`;

--- a/src/use/phone/useAgentState.js
+++ b/src/use/phone/useAgentState.js
@@ -88,7 +88,9 @@ export default ({
    * Toggle agent connection state.
    * @returns {Promise<void>}
    */
-  const toggleAgentState = async () => {
+  const toggleAgentState = async ({
+    userInitiated = false,
+  }: { userInitiated: boolean } = {}) => {
     if (!_agent.value) {
       context.root.$log.error(
         'tried to change agent state, but no agent available!',
@@ -97,9 +99,11 @@ export default ({
       return;
     }
     if (ctrlGetters.isCallActive.value) {
-      context.root.$toasted.error(
-        context.root.$t('phoneDashboard.call_status_required_before_next'),
-      );
+      if (userInitiated) {
+        context.root.$toasted.error(
+          context.root.$t('phoneDashboard.call_status_required_before_next'),
+        );
+      }
       return;
     }
     _agent.value.toggleOnline();


### PR DESCRIPTION
Closes #1063

* Prevents the agent from exiting ACW without first closing an active case.
* Prevent clearing contact data on ACW exit attempt if case is still open.
* Ensure Api knows when an outbound call is a manual

