### PR TITLE
Improve Agent verification in/out flow by bypassing redial

### DIFF
--- a/src/models/phone/AgentClient.js
+++ b/src/models/phone/AgentClient.js
@@ -50,9 +50,9 @@ export const RouteStates = Object.freeze({
 const Log = Logger({ name: 'phone.agent' });
 
 export default class AgentClient extends Model {
-  static entity = 'phone/agent';
+  static entity: string = 'phone/agent';
 
-  static primaryKey = 'agentId';
+  static primaryKey: string = 'agentId';
 
   static fields() {
     return ({

--- a/src/services/connect.service.js
+++ b/src/services/connect.service.js
@@ -252,3 +252,32 @@ export const connectEndpoint = (phoneNumber: string) => {
     },
   );
 };
+
+/**
+ * Add agent verification endpoint to current connection.
+ * @param contact - contact of current connection.
+ * @returns {*}
+ */
+export const getAgentVerificationEndpoint = (
+  contact: typeof connect.Contact,
+) => {
+  const agent = new connect.Agent();
+  let eps;
+  agent.getEndpoints(agent.getAllQueueARNs(), {
+    success: (data) => {
+      Log.info('retrieved agent endpoints!', data);
+      Log.info('queues:', agent.getAllQueueARNs());
+      contact.addConnection(data.endpoints[2], {
+        success: () => Log.info('successfully transferred!'),
+        failure: () => Log.error('failed to transfer!'),
+      });
+
+      eps = data.endpoints;
+    },
+    failure: (e) => Log.error('Failed to retrieve agent endpoints!', e),
+  });
+  if (eps) {
+    return eps.find((e) => e.type === 'queue');
+  }
+  return null;
+};

--- a/src/services/connect.service.js
+++ b/src/services/connect.service.js
@@ -125,14 +125,16 @@ export const initConnect = ({
  * @param contactId - ID of contact to retrieve.
  * @returns {null|connect.Contact}
  */
-export const getContactById = (contactId: string): connect.Contact | null => {
-  const agent: connect.Agent = new connect.Agent();
-  const contacts: connect.Contact[] = agent.getContacts();
+export const getContactById = (
+  contactId: string,
+): typeof connect.Contact | null => {
+  const agent: typeof connect.Agent = new connect.Agent();
+  const contacts: typeof connect.Contact[] = agent.getContacts();
   if (_.isEmpty(contacts)) {
     return null;
   }
   let targContact = contacts.find(
-    (c: connect.Contact) => c.getInitialContactId() === contactId,
+    (c: typeof connect.Contact) => c.getInitialContactId() === contactId,
   );
   if (!targContact) {
     // In the case of an outbound call,
@@ -141,7 +143,7 @@ export const getContactById = (contactId: string): connect.Contact | null => {
     // So we will need the current contact ID, rather than the
     // initial.
     targContact = contacts.find(
-      (c: connect.Contact) => c.getContactId() === contactId,
+      (c: typeof connect.Contact) => c.getContactId() === contactId,
     );
     if (targContact) {
       return targContact;
@@ -150,7 +152,7 @@ export const getContactById = (contactId: string): connect.Contact | null => {
     // before connect (and its an outbound), then just use
     // the current contact who is a queue callback.
     targContact = contacts.find(
-      (c: connect.Contact) => c.getType() === 'queue_callback',
+      (c: typeof connect.Contact) => c.getType() === 'queue_callback',
     );
     if (targContact) {
       return targContact;
@@ -169,10 +171,10 @@ export const getContactById = (contactId: string): connect.Contact | null => {
  */
 export const getConnectionByContactId = (
   contactId: string,
-): connect.Connection | null => {
+): typeof connect.Connection | null => {
   const targContact = getContactById(contactId);
   if (targContact === null) return null;
-  const targConnection: void | connect.ConnectionType = targContact.getInitialConnection();
+  const targConnection: typeof connect.ConnectionType = targContact.getInitialConnection();
   return targConnection || null;
 };
 

--- a/src/services/connect.service.js
+++ b/src/services/connect.service.js
@@ -61,6 +61,7 @@ export const ContactEvents = Object.freeze({
   ON_ACW: 'onACW',
   ON_DESTROY: 'onDestroy',
   ON_INCOMING: 'onIncoming',
+  ON_REFRESH: 'onRefresh',
 });
 
 /**

--- a/src/services/connect.service.js
+++ b/src/services/connect.service.js
@@ -224,3 +224,31 @@ export const setAgentState = (online: boolean = true) => {
     },
   });
 };
+
+/**
+ * Connect agent to a phone number via outbound flow.
+ * @param phoneNumber - phone number to manually dial.
+ */
+export const connectEndpoint = (phoneNumber: string) => {
+  const endpoint = connect.Endpoint.byPhoneNumber(phoneNumber);
+  const agent = new connect.Agent();
+  if (!agent) {
+    Log.error('cannot dial number because there is no agent!');
+    return;
+  }
+
+  const client = connect.core.getClient();
+  const endpointOut = new connect.Endpoint(endpoint);
+  delete endpointOut.endpointId;
+  client.call(
+    connect.ClientMethods.CREATE_OUTBOUND_CONTACT,
+    {
+      endpoint: connect.assertNotNull(endpointOut, 'endpoint'),
+      queueARN: agent.getRoutingProfile().defaultOutboundQueue.queueARN,
+    },
+    {
+      success: () => Log.info('outbound call placed successfully!'),
+      failure: (e) => Log.error('failed to place outbound call:', e),
+    },
+  );
+};

--- a/src/store/modules/phone/controller.js
+++ b/src/store/modules/phone/controller.js
@@ -28,12 +28,7 @@ import _ from 'lodash';
 import Agent from '@/models/Agent';
 import Worksite from '@/models/Worksite';
 import Pda from '@/models/Pda';
-import Contact, {
-  CallType,
-  ContactActions,
-  ContactAttributes,
-  ContactStates,
-} from '@/models/phone/Contact';
+import Contact, { CallType, ContactActions } from '@/models/phone/Contact';
 import PhoneOutbound from '@/models/PhoneOutbound';
 import PhoneInbound from '@/models/PhoneInbound';
 import User from '@/models/User';
@@ -399,34 +394,6 @@ class ControllerStore extends VuexModule {
         await PhoneOutbound.api().callOutbound(outbound.id, {
           isManual: manual,
         });
-        const contactId = outboundObj.external_id
-          ? outboundObj.external_id
-          : `${agent.agentId}#manual-outbound`;
-        const outboundTypeMap = {
-          callback: CallType.OUTBOUND,
-          calldown: CallType.CALLDOWN,
-        };
-        const contactPayload = {
-          contactId,
-          action: ContactActions.PENDING,
-          state: ContactStates.QUEUED,
-          attributes: {
-            [ContactAttributes.CALL_TYPE]: CallType.OUTBOUND,
-            [ContactAttributes.CALLER_ID]: outbound.phone_number,
-            [ContactAttributes.INBOUND_NUMBER]: outbound.phone_number,
-            [ContactAttributes.CALLER_DNIS_ID]: outbound.dnis1,
-            [ContactAttributes.OUTBOUND_TYPE]:
-              outboundTypeMap[outbound.call_type],
-          },
-        };
-        Log.debug('creating outbound contact!', contactPayload);
-        await this.context.dispatch(
-          'phone.streams/updateContact',
-          contactPayload,
-          {
-            root: true,
-          },
-        );
       } catch (e) {
         if (e.response) {
           if (e.response.status === 423) {

--- a/src/store/modules/phone/streams.js
+++ b/src/store/modules/phone/streams.js
@@ -262,6 +262,17 @@ class StreamsStore extends VuexModule {
     return newData;
   }
 
+  /**
+   * Begins an outbound call from the current agent.
+   * @param phoneNumber - number to dial.
+   * @returns {Promise<void>}
+   */
+  @Action
+  async connectEndpoint({ phoneNumber }: { phoneNumber: string }) {
+    Log.info(`Dialing phone number: ${phoneNumber}`);
+    ACS.connectEndpoint(phoneNumber);
+  }
+
   @Action
   async init({ element }: { element: HTMLElement }) {
     Log.info('Initializing ACS streams store!');


### PR DESCRIPTION
Reworks the flows to where it is no longer necessary to hang up and redial the agent after confirming the agent.

Also no longer utilizes queued callbacks, which solves several of our biggest "why am I getting a call/same call keeps coming in" issues.

Closes #955

- fix(phone): typing errors
- feat(connect): add method for invoking agent driven outbound call from client
- feat(connect): add method for transfering agent to verification endpoint
- feat(streams): add action to invoke outbound call from streams module
- feat(streams): immediately place inbound calls on hold and consider them as still connecting
- feat(streams): monitor contact for third party verification connection and destroy it on completion
- feat(ctrl): do not pre-create outbound contact when served anymore
