### PR TITLE
Pewpew Layout Fixes

### DIFF
--- a/src/components/OrganizationActivityModal.vue
+++ b/src/components/OrganizationActivityModal.vue
@@ -99,7 +99,7 @@
           :columns="incidentTable.columns"
           :data="generalInfo.statistics"
           :body-style="{ maxHeight: '40vh', ...styles }"
-          :header-style="styles"
+          :header-style="{ ...styles, marginBottom: '-10px' }"
           :row-style="{ backgroundColor: 'unset' }"
         >
           <template #name="slotProps">

--- a/src/components/charts/CircularBarplot.vue
+++ b/src/components/charts/CircularBarplot.vue
@@ -51,7 +51,7 @@ export default {
     /**
      * background color / gradient
      */
-    bgColor: VueTypes.string.def('#232323'),
+    bgColor: VueTypes.string.def('transparent'),
   },
 
   data() {

--- a/src/components/charts/D3BarChart.vue
+++ b/src/components/charts/D3BarChart.vue
@@ -46,7 +46,7 @@ export default {
     /**
      * background color / gradient
      */
-    bgColor: VueTypes.string.def('#232323'),
+    bgColor: VueTypes.string.def('transparent'),
     /**
      * Stacked | Unstacked
      */

--- a/src/components/charts/SiteActivityGauge.vue
+++ b/src/components/charts/SiteActivityGauge.vue
@@ -27,7 +27,7 @@ export default {
     /**
      * background color / gradient
      */
-    bgColor: VueTypes.string.def('#232323'),
+    bgColor: VueTypes.string.def('transparent'),
   },
 
   data() {

--- a/src/components/tabs/Tab.vue
+++ b/src/components/tabs/Tab.vue
@@ -17,6 +17,14 @@ export default {
     };
   },
 
+  watch: {
+    selected: {
+      handler() {
+        this.isActive = this.selected;
+      },
+    },
+  },
+
   computed: {
     href() {
       return `#${this.name.toLowerCase().replace(/ /g, '-')}`;

--- a/src/pages/unauthenticated/PewPew.vue
+++ b/src/pages/unauthenticated/PewPew.vue
@@ -100,8 +100,8 @@
             tab-active-classes="bg-gradient-to-t from-crisiscleanup-dark-500 to-crisiscleanup-dark-400 rounded-t-xl"
             @tabSelected="stopSiteInfoTabCirculationTimer"
           >
-            <LightTab
-              :name="$t('Live')"
+            <tab
+              :name="$t('~~Live')"
               :selected="
                 siteInfoTimerData.isTimerActive &&
                 siteInfoTimerData.activeInfoTab === 0
@@ -123,8 +123,8 @@
               <div class="h-full p-2 w-full" v-if="liveEvents.length > 0">
                 <CardStack ref="cards" :key="incidentId" />
               </div>
-            </LightTab>
-            <LightTab
+            </tab>
+            <tab
               :name="$t('reports.pp_site_stats_title')"
               class="p-2"
               :selected="
@@ -225,7 +225,7 @@
                   </div>
                 </div>
               </div>
-            </LightTab>
+            </tab>
           </tabs>
         </div>
       </div>

--- a/src/pages/unauthenticated/PewPew.vue
+++ b/src/pages/unauthenticated/PewPew.vue
@@ -662,7 +662,7 @@
                   class="chart-tab"
                   :selected="
                     chartCirculationTimerData.isTimerActive &&
-                    chartCirculationTimerData.activeChartTab === 2
+                    chartCirculationTimerData.activeChartTab === 1
                   "
                 >
                   <div class="chart-container rounded-t-xl">
@@ -684,7 +684,7 @@
                   class="chart-tab"
                   :selected="
                     chartCirculationTimerData.isTimerActive &&
-                    chartCirculationTimerData.activeChartTab === 1
+                    chartCirculationTimerData.activeChartTab === 2
                   "
                 >
                   <div class="chart-container rounded-t-xl">

--- a/src/pages/unauthenticated/PewPew.vue
+++ b/src/pages/unauthenticated/PewPew.vue
@@ -93,11 +93,11 @@
         </div>
         <div class="col-span-6 flex flex-col justify-between items-center">
           <tabs
-            class="relative h-full w-full px-1 mt-10"
+            class="relative h-full w-full px-1 mt-10 mx-1"
             ref="tabs"
             tab-classes="text-xs"
             tab-default-classes="flex items-center justify-center h-8 cursor-pointer px-2"
-            tab-active-classes="bg-gradient-to-t from-crisiscleanup-dark-500 to-crisiscleanup-dark-400 rounded-t-xl"
+            tab-active-classes="bg-crisiscleanup-dark-400 rounded-t-xl"
             @tabSelected="stopSiteInfoTabCirculationTimer"
           >
             <tab
@@ -106,8 +106,18 @@
                 siteInfoTimerData.isTimerActive &&
                 siteInfoTimerData.activeInfoTab === 0
               "
+              class="absolute mx-1 left-0 right-0"
+              :style="{ top: '2rem', bottom: 0 }"
             >
-              <div :name="$t('reports.pp_engagement_title')" class="w-full">
+              <div
+                class="
+                  rounded-tr-xl
+                  bg-gradient-to-b
+                  from-crisiscleanup-dark-400
+                  via-crisiscleanup-dark-500
+                "
+                :name="$t('reports.pp_engagement_title')"
+              >
                 <div class="text-xs px-5 text-center">
                   {{ $t('reports.pp_engagement_title') }}
                 </div>
@@ -126,13 +136,26 @@
             </tab>
             <tab
               :name="$t('reports.pp_site_stats_title')"
-              class="p-2"
               :selected="
                 siteInfoTimerData.isTimerActive &&
                 siteInfoTimerData.activeInfoTab === 1
               "
+              class="absolute mx-1 left-0 right-0"
+              :style="{ top: '2rem', bottom: 0 }"
             >
-              <div class="flex flex-col items-start justify-start w-full">
+              <div
+                class="
+                  flex flex-col
+                  items-start
+                  justify-start
+                  p-2
+                  w-full
+                  rounded-t-xl
+                  bg-gradient-to-b
+                  from-crisiscleanup-dark-400
+                  via-crisiscleanup-dark-500
+                "
+              >
                 <div class="">
                   <div class="mb-2">
                     <div>

--- a/src/pages/unauthenticated/PewPew.vue
+++ b/src/pages/unauthenticated/PewPew.vue
@@ -476,10 +476,30 @@
                       bg-opacity-25
                     "
                   >
-                    <div class="font-bold my-1 text-white text-sm">
-                      {{ $t('worksiteMap.legend') }}
+                    <div
+                      class="
+                        flex
+                        justify-between
+                        font-bold
+                        my-1
+                        text-white text-sm
+                      "
+                    >
+                      <span>
+                        {{ $t('worksiteMap.legend') }}
+                      </span>
+                      <span
+                        class="cursor-pointer"
+                        @click="isLegendHidden = !isLegendHidden"
+                      >
+                        <font-awesome-icon v-if="!isLegendHidden" icon="minus" />
+                        <font-awesome-icon v-else icon="plus" />
+                      </span>
                     </div>
-                    <div class="flex flex-wrap justify-between">
+                    <div
+                      class="flex flex-wrap justify-between"
+                      v-if="!isLegendHidden"
+                    >
                       <div
                         v-for="entry in displayedWorkTypeSvgs"
                         :key="entry.key"
@@ -878,6 +898,7 @@ export default {
       orbTexture: null,
       eventsInterval: null,
       textureMap: {},
+      isLegendHidden: false,
       queryFilter: {
         start_date: null,
         end_date: null,

--- a/src/pages/unauthenticated/PewPew.vue
+++ b/src/pages/unauthenticated/PewPew.vue
@@ -292,7 +292,7 @@
           </div>
         </div>
         <div class="flex-grow grid grid-cols-12">
-          <div class="col-span-9 flex flex-col">
+          <div class="col-span-8 flex flex-col">
             <div class="flex-grow">
               <div class="relative h-full">
                 <div
@@ -582,7 +582,7 @@
               </div>
             </div>
           </div>
-          <div class="col-span-3 grid grid-rows-12">
+          <div class="col-span-4 grid grid-rows-12">
             <div class="row-span-7 relative">
               <OrganizationActivityModal
                 @close="closeModal"

--- a/src/pages/unauthenticated/PewPew.vue
+++ b/src/pages/unauthenticated/PewPew.vue
@@ -609,22 +609,36 @@
                   />
                   <span class="truncate w-32">{{ slotProps.item.name }}</span>
                 </template>
+                <template #incident_count="slotProps">
+                  <span class="w-full flex justify-end">
+                    {{ nFormatter(slotProps.item.incident_count) }}
+                  </span>
+                </template>
                 <template #commercial_value="slotProps">
-                  {{ nFormatter(slotProps.item.commercial_value) }}
+                  <span class="w-full flex justify-end">
+                    ${{ nFormatter(slotProps.item.commercial_value) }}
+                  </span>
+                </template>
+                <template #calls_count="slotProps">
+                  <span class="w-full flex justify-end">
+                    ${{ nFormatter(slotProps.item.calls_count) }}
+                  </span>
                 </template>
                 <template #reported_count="slotProps">
-                  <CaseDonutChart
-                    class="w-8 h-8"
-                    :chart-id="`case-donut-chart-${slotProps.item.id}`"
-                    :chart-data="{
-                      reportedCases: slotProps.item.reported_count || 0,
-                      claimedCases:
-                        (slotProps.item.claimed_count || 0) -
-                        (slotProps.item.closed_count || 0),
-                      completedCases: slotProps.item.closed_count || 0,
-                    }"
-                    :bg-color="styles.backgroundColor"
-                  />
+                  <div class="w-full flex justify-end">
+                    <CaseDonutChart
+                      class="w-8 h-8"
+                      :chart-id="`case-donut-chart-${slotProps.item.id}`"
+                      :chart-data="{
+                        reportedCases: slotProps.item.reported_count || 0,
+                        claimedCases:
+                          (slotProps.item.claimed_count || 0) -
+                          (slotProps.item.closed_count || 0),
+                        completedCases: slotProps.item.closed_count || 0,
+                      }"
+                      :bg-color="styles.backgroundColor"
+                    />
+                  </div>
                 </template>
               </Table>
             </div>

--- a/src/pages/unauthenticated/PewPew.vue
+++ b/src/pages/unauthenticated/PewPew.vue
@@ -467,7 +467,7 @@
                     v-if="displayedWorkTypeSvgs.length > 0"
                     class="
                       legend
-                      w-108
+                      w-56
                       h-auto
                       bg-crisiscleanup-dark-400
                       p-2
@@ -492,40 +492,50 @@
                         class="cursor-pointer"
                         @click="isLegendHidden = !isLegendHidden"
                       >
-                        <font-awesome-icon v-if="!isLegendHidden" icon="minus" />
+                        <font-awesome-icon
+                          v-if="!isLegendHidden"
+                          icon="minus"
+                        />
                         <font-awesome-icon v-else icon="plus" />
                       </span>
                     </div>
-                    <div
-                      class="flex flex-wrap justify-between"
-                      v-if="!isLegendHidden"
-                    >
+                    <transition name="fade">
                       <div
-                        v-for="entry in displayedWorkTypeSvgs"
-                        :key="entry.key"
-                        class="
-                          flex
-                          items-center
-                          w-1/2
-                          mb-1
-                          cursor-pointer
-                          hover:border-2
-                        "
-                        :class="entry.selected ? 'selected border-2' : 'my-1'"
-                        @click="
-                          () => {
-                            entry.selected = !entry.selected;
-                            displayedWorkTypeSvgs = [...displayedWorkTypeSvgs];
-                            refresh();
-                          }
-                        "
+                        class="flex flex-wrap justify-between"
+                        v-if="!isLegendHidden"
                       >
-                        <div class="map-svg-container" v-html="entry.svg"></div>
-                        <span class="text-xs ml-1 text-white">{{
-                          entry.key | getWorkTypeName
-                        }}</span>
+                        <div
+                          v-for="entry in displayedWorkTypeSvgs"
+                          :key="entry.key"
+                          class="
+                            flex
+                            items-center
+                            w-1/2
+                            mb-1
+                            cursor-pointer
+                            hover:border-2
+                          "
+                          :class="entry.selected ? 'selected border-2' : 'my-1'"
+                          @click="
+                            () => {
+                              entry.selected = !entry.selected;
+                              displayedWorkTypeSvgs = [
+                                ...displayedWorkTypeSvgs,
+                              ];
+                              refresh();
+                            }
+                          "
+                        >
+                          <div
+                            class="map-svg-container"
+                            v-html="entry.svg"
+                          ></div>
+                          <span class="text-xs ml-1 text-white">{{
+                            entry.key | getWorkTypeName
+                          }}</span>
+                        </div>
                       </div>
-                    </div>
+                    </transition>
                   </div>
                   <div class="relative">
                     <img

--- a/src/pages/unauthenticated/PewPew.vue
+++ b/src/pages/unauthenticated/PewPew.vue
@@ -630,24 +630,23 @@
             </div>
             <div class="row-span-5">
               <tabs
-                class="relative h-full"
+                class="relative h-full m-1"
                 ref="tabs"
                 tab-classes="text-xs"
-                tab-default-classes="flex items-center justify-center text-center h-8 cursor-pointer px-2"
-                tab-active-classes="bg-gradient-to-t from-crisiscleanup-dark-500 to-crisiscleanup-dark-400 rounded-t-xl"
+                tab-default-classes="flex items-center justify-center text-center h-10 cursor-pointer px-2"
+                tab-active-classes="bg-crisiscleanup-dark-400 rounded-t-xl"
                 @tabSelected="stopChartTabCirculationTimer"
               >
                 <LightTab
                   :name="$t('reports.pp_call_volume_title')"
                   :alt="$t('reports.pp_call_volume_description')"
-                  class="absolute left-0 right-0"
-                  style="top: 10%; bottom: 5%"
+                  class="chart-tab"
                   :selected="
                     chartCirculationTimerData.isTimerActive &&
                     chartCirculationTimerData.activeChartTab === 0
                   "
                 >
-                  <div class="absolute top-0 bottom-0 left-0 right-0">
+                  <div class="chart-container rounded-tr-xl">
                     <CircularBarplot
                       v-if="circularBarplotData.length !== 0"
                       class="h-full h-full"
@@ -660,14 +659,13 @@
                 <LightTab
                   :name="$t('reports.pp_total_cases_title')"
                   :alt="$t('reports.pp_total_cases_description')"
-                  class="absolute left-0 right-0"
-                  style="top: 10%; bottom: 5%"
+                  class="chart-tab"
                   :selected="
                     chartCirculationTimerData.isTimerActive &&
                     chartCirculationTimerData.activeChartTab === 2
                   "
                 >
-                  <div class="absolute top-0 bottom-0 left-0 right-0">
+                  <div class="chart-container rounded-t-xl">
                     <TotalCases
                       class="h-full w-full"
                       :margin-all="30"
@@ -683,14 +681,13 @@
                 </LightTab>
                 <LightTab
                   :name="$t('~~Completion Rate')"
-                  class="absolute bottom-0 left-0 right-0"
-                  style="top: 10%; bottom: 5%"
+                  class="chart-tab"
                   :selected="
                     chartCirculationTimerData.isTimerActive &&
                     chartCirculationTimerData.activeChartTab === 1
                   "
                 >
-                  <div class="absolute top-0 bottom-0 left-0 right-0">
+                  <div class="chart-container rounded-t-xl">
                     <D3BarChart
                       class="h-full w-full"
                       chart-id="completion-rate"
@@ -701,14 +698,13 @@
                 </LightTab>
                 <LightTab
                   :name="$t('~~Weeks To Completion')"
-                  class="absolute bottom-0 left-0 right-0"
-                  style="top: 10%; bottom: 5%"
+                  class="chart-tab"
                   :selected="
                     chartCirculationTimerData.isTimerActive &&
                     chartCirculationTimerData.activeChartTab === 3
                   "
                 >
-                  <div class="absolute top-0 bottom-0 left-0 right-0">
+                  <div class="chart-container rounded-tl-xl">
                     <WeeksToCompletion
                       :margin-all="30"
                       class="h-full w-full"
@@ -1997,6 +1993,24 @@ export default {
       #819ab0 75.52%,
       rgba(129, 154, 176, 0) 100.43%
     );
+  }
+
+  /* set top to 2.5rem to place it after tab headers which has a h-10 = 2.5rem */
+  .chart-tab {
+    @apply absolute left-0 right-0;
+    top: 2.5rem;
+    bottom: 0;
+  }
+
+  .chart-container {
+    @apply absolute
+      top-0
+      bottom-0
+      left-0
+      right-0
+      bg-gradient-to-b
+      from-crisiscleanup-dark-400
+      via-crisiscleanup-dark-500;
   }
 
   ::-webkit-scrollbar {


### PR DESCRIPTION
- fix(comp): add neg margin to header style to remove unnecessary spacing
- feat(pewpew): increase col span for right section with tables and charts
- feat(comp/tabs): add watcher on `Tab` selection prop to update active tab
- feat(pewpew): switch `LightTab` with `Tab` for site info tabs to avoid unmounting event stream
- feat(comp/charts): change default background color prop to transparent
- feat(pewpew): change chart tabs style + refactor styles
- fix(pewpew): fix tab rotation tab numbers
- fix(pewpew): fix organization table row alignment
- feat(comp/charts): change default background color prop to transparent for `SiteActivityGauge`
- feat(pewpew): add tab gradient formatting to site info tabs
- feat(pewpew): add collapse functionality to map legend
- feat(pewpew): reduce legend width, add fade transition on show/hide legend