### PR TITLE
fix/pewpew/chart performance

### DIFF
--- a/src/components/charts/CircularBarplot.vue
+++ b/src/components/charts/CircularBarplot.vue
@@ -178,17 +178,6 @@ export default {
       totalCallsGroup
         .attr('transform', 'scale(1.4)')
         .style('opacity', '0')
-        .attr(
-          'd',
-          d3
-            .arc()
-            .innerRadius(this.y(0))
-            .outerRadius((d) => this.y(d.calls))
-            .startAngle((d) => this.x(d.name))
-            .endAngle((d) => this.x(d.name) + this.x.bandwidth())
-            .padAngle(0.015)
-            .padRadius((d) => this.y(d.calls)),
-        )
         .transition()
         .delay((d, i) => i * 15)
         .duration(500)
@@ -200,8 +189,7 @@ export default {
             .outerRadius((d) => this.y(d.calls))
             .startAngle((d) => this.x(d.name))
             .endAngle((d) => this.x(d.name) + this.x.bandwidth())
-            .padAngle(0.05)
-            .padRadius(this.getInnerRadius()),
+            .padAngle(0.05),
         )
         .style('opacity', '1')
         .attr('transform', 'scale(1)');
@@ -240,17 +228,6 @@ export default {
       missedCallsGroup
         .attr('transform', 'scale(1.2)')
         .style('opacity', '0')
-        .attr(
-          'd',
-          d3
-            .arc()
-            .innerRadius(this.y(0))
-            .outerRadius((d) => this.y(d.missed))
-            .startAngle((d) => this.x(d.name))
-            .endAngle((d) => this.x(d.name) + this.x.bandwidth())
-            .padAngle(0.05)
-            .padRadius(this.getInnerRadius()),
-        )
         .transition()
         .delay((d, i) => i * 15)
         .duration(500)
@@ -262,8 +239,7 @@ export default {
             .outerRadius((d) => this.y(d.missed))
             .startAngle((d) => this.x(d.name))
             .endAngle((d) => this.x(d.name) + this.x.bandwidth())
-            .padAngle(0.05)
-            .padRadius(this.getInnerRadius()),
+            .padAngle(0.05),
         )
         .style('opacity', '1')
         .attr('transform', 'scale(1)');

--- a/src/components/charts/CircularBarplot.vue
+++ b/src/components/charts/CircularBarplot.vue
@@ -7,6 +7,7 @@
 import * as d3 from 'd3';
 import VueTypes from 'vue-types';
 import _ from 'lodash';
+import { D3BaseChartMixin } from '@/mixins';
 
 export type CallVolumeDataT = {|
   name: string,
@@ -17,6 +18,7 @@ export type CallVolumeDataT = {|
 
 export default {
   name: 'CircularBarplot',
+  mixins: [D3BaseChartMixin],
   props: {
     /**
      * Data for Donut chart
@@ -39,32 +41,10 @@ export default {
       required: false,
       default: true,
     },
-
-    /**
-     * Unique chart ID
-     */
-    chartId: VueTypes.string.def('d3-circular-barplot'),
-    /**
-     * top, bottom, left, right margins
-     */
-    marginAll: VueTypes.number.def(5),
-    /**
-     * background color / gradient
-     */
-    bgColor: VueTypes.string.def('transparent'),
   },
 
   data() {
     return {
-      margin: {
-        left: 0,
-        right: 0,
-        top: 0,
-        bottom: 0,
-      },
-      svg: null,
-      x: null,
-      y: null,
       timeScale: null,
       colorScale: null,
       textContainer: null,
@@ -75,32 +55,6 @@ export default {
       mappedMissedCalls: null,
       mappedTimestamps: null,
     };
-  },
-
-  mounted() {
-    if (!_.isEmpty(this.chartData)) {
-      this.$nextTick(() => {
-        this.margin.top = this.marginAll;
-        this.margin.bottom = this.marginAll;
-        this.margin.left = this.marginAll;
-        this.margin.right = this.marginAll;
-
-        this.destroyChart();
-        this.renderChart();
-      });
-    } else {
-      console.log('No data found');
-    }
-
-    window.addEventListener(
-      'resize',
-      _.debounce(() => {
-        if (!_.isEmpty(this.chartData)) {
-          this.destroyChart();
-          this.renderChart();
-        }
-      }, 1500),
-    );
   },
 
   watch: {
@@ -114,32 +68,9 @@ export default {
         }
       },
     },
-
-    isStacked: {
-      handler() {
-        this.destroyChart();
-        this.renderChart();
-      },
-    },
   },
 
   methods: {
-    getWidth(): number {
-      return +d3.select(`#${this.chartId}`).style('width').slice(0, -2) || 0;
-    },
-
-    getHeight(): number {
-      return +d3.select(`#${this.chartId}`).style('height').slice(0, -2) || 0;
-    },
-
-    getInnerWidth(): number {
-      return this.getWidth() - this.margin.left - this.margin.right;
-    },
-
-    getInnerHeight(): number {
-      return this.getHeight() - this.margin.top - this.margin.bottom;
-    },
-
     getInnerRadius(): number {
       return Math.min(this.getInnerWidth(), this.getInnerHeight()) / 5;
     },
@@ -472,10 +403,6 @@ export default {
         .attr('font-size', `${this.getFontSize()}px`)
         .attr('x', 0)
         .attr('y', `${2.5 * this.getFontSize()}px`);
-    },
-
-    destroyChart() {
-      d3.select(`#${this.chartId} svg`).remove();
     },
   },
 };

--- a/src/components/charts/D3BarChart.vue
+++ b/src/components/charts/D3BarChart.vue
@@ -7,6 +7,7 @@
 import * as d3 from 'd3';
 import VueTypes from 'vue-types';
 import _ from 'lodash';
+import { D3BaseChartMixin } from '@/mixins';
 
 export type BarChartT = {|
   group: Date | number | string,
@@ -16,12 +17,9 @@ export type BarChartT = {|
 
 export default {
   name: 'D3BarChart',
+  mixins: [D3BaseChartMixin],
   components: {},
   props: {
-    /**
-     * Unique chart ID
-     */
-    chartId: VueTypes.string.def('d3-bar-chart'),
     /**
      * Data for Bar chart
      */
@@ -34,14 +32,6 @@ export default {
       { group: new Date('2021-08-20'), newCases: 24, closedCases: 35 },
     ]),
     /**
-     * top, bottom, left, right margins
-     */
-    marginAll: VueTypes.number.def(25),
-    /**
-     * background color / gradient
-     */
-    bgColor: VueTypes.string.def('transparent'),
-    /**
      * Stacked | Unstacked
      */
     isStacked: VueTypes.bool.def(false),
@@ -49,17 +39,8 @@ export default {
 
   data() {
     return {
-      svg: null,
-      x: null,
-      y: null,
       colorScale: null,
       colorRange: ['#00C4FF', '#728090'],
-      margin: {
-        left: 0,
-        right: 0,
-        top: 0,
-        bottom: 0,
-      },
     };
   },
 
@@ -74,65 +55,9 @@ export default {
     },
   },
 
-  mounted() {
-    this.$nextTick(() => {
-      this.margin.top = this.marginAll;
-      this.margin.bottom = this.marginAll + 10;
-      this.margin.left = this.marginAll;
-      this.margin.right = this.marginAll;
-
-      this.addHeaderCol();
-      this.destroyChart();
-      this.renderChart();
-    });
-
-    window.addEventListener(
-      'resize',
-      _.debounce(() => {
-        this.destroyChart();
-        this.renderChart();
-      }, 1500),
-    );
-  },
-
-  beforeDestroy() {
-    window.removeEventListener('resize', () => {});
-  },
-
-  computed: {},
-
   methods: {
-    getWidth(): number {
-      return +d3.select(`#${this.chartId}`).style('width').slice(0, -2) || 0;
-    },
-
-    getHeight(): number {
-      return +d3.select(`#${this.chartId}`).style('height').slice(0, -2) || 0;
-    },
-
-    getInnerWidth(): number {
-      return this.getWidth() - this.margin.left - this.margin.right;
-    },
-
-    getInnerHeight(): number {
-      return this.getHeight() - this.margin.top - this.margin.bottom;
-    },
-
     getFontSize(): number {
       return (this.getWidth() + this.getHeight()) * 0.012;
-    },
-
-    // add header columns to chartData array for d3 stacking
-    addHeaderCol() {
-      if (!_.isEmpty(this.chartData)) {
-        this.chartData.columns = _.keys(this.chartData[0]);
-      } else {
-        this.chartData.columns = [];
-      }
-    },
-
-    destroyChart() {
-      d3.select(`#${this.chartId} svg`).remove();
     },
 
     loadSvg() {
@@ -194,6 +119,12 @@ export default {
     },
 
     renderChart() {
+      // add header columns to chartData array for d3 stacking
+      if (!_.isEmpty(this.chartData)) {
+        this.chartData.columns = _.keys(this.chartData[0]);
+      } else {
+        this.chartData.columns = [];
+      }
       if (this.isStacked) {
         this.renderStackedChart();
       } else {

--- a/src/components/charts/D3BarChart.vue
+++ b/src/components/charts/D3BarChart.vue
@@ -25,19 +25,13 @@ export default {
     /**
      * Data for Bar chart
      */
-    chartData: VueTypes.arrayOf(
-      VueTypes.shape<BarChartT>({
-        group: VueTypes.number,
-        newCases: VueTypes.number,
-        closedCases: VueTypes.number,
-      }).def(() => ({ group: 0, newCases: 0, closedCases: 0 })).isRequired,
-    ).def((): BarChartT[] => [
-      { group: 0, newCases: 28, closedCases: 30 },
-      { group: 1, newCases: 43, closedCases: 38 },
-      { group: 2, newCases: 81, closedCases: 30 },
-      { group: 3, newCases: 19, closedCases: 80 },
-      { group: 4, newCases: 52, closedCases: 30 },
-      { group: 5, newCases: 24, closedCases: 35 },
+    chartData: VueTypes.arrayOf(VueTypes.object).def((): BarChartT[] => [
+      { group: new Date('2021-08-15'), newCases: 28, closedCases: 30 },
+      { group: new Date('2021-08-16'), newCases: 43, closedCases: 38 },
+      { group: new Date('2021-08-17'), newCases: 81, closedCases: 30 },
+      { group: new Date('2021-08-18'), newCases: 19, closedCases: 80 },
+      { group: new Date('2021-08-19'), newCases: 52, closedCases: 30 },
+      { group: new Date('2021-08-20'), newCases: 24, closedCases: 35 },
     ]),
     /**
      * top, bottom, left, right margins

--- a/src/components/charts/D3BarChart.vue
+++ b/src/components/charts/D3BarChart.vue
@@ -10,7 +10,7 @@ import _ from 'lodash';
 import { D3BaseChartMixin } from '@/mixins';
 
 export type BarChartT = {|
-  group: Date | number | string,
+  group: Date,
   newCases: number,
   closedCases: number,
 |};
@@ -46,11 +46,12 @@ export default {
 
   watch: {
     chartData: {
-      deep: true,
-      handler() {
-        this.addHeaderCol();
-        this.destroyChart();
-        this.renderChart();
+      handler(newValue, oldValue) {
+        if (!_.isEmpty(newValue) && _.isEmpty(oldValue)) {
+          this.doRerender();
+        } else {
+          console.log('No data found');
+        }
       },
     },
   },
@@ -119,6 +120,8 @@ export default {
     },
 
     renderChart() {
+      // override default bottom margin to make space for x-axis
+      this.margin.bottom = 40;
       // add header columns to chartData array for d3 stacking
       if (!_.isEmpty(this.chartData)) {
         this.chartData.columns = _.keys(this.chartData[0]);

--- a/src/components/charts/SiteActivityGauge.vue
+++ b/src/components/charts/SiteActivityGauge.vue
@@ -7,110 +7,44 @@
 import * as d3 from 'd3';
 import VueTypes from 'vue-types';
 import _ from 'lodash';
+import { D3BaseChartMixin } from '@/mixins';
 
 export default {
   name: 'SiteActivityGauge',
-  components: {},
+  mixins: [D3BaseChartMixin],
   props: {
-    /**
-     * Unique chart ID
-     */
-    chartId: VueTypes.string.def('d3-site-activity-gauge'),
     /**
      * Data for gauge
      */
     chartData: VueTypes.number.def(35),
-    /**
-     * top, bottom, left, right margins
-     */
-    marginAll: VueTypes.number.def(5),
-    /**
-     * background color / gradient
-     */
-    bgColor: VueTypes.string.def('transparent'),
   },
 
   data() {
     return {
-      svg: null,
-      x: null,
-      y: null,
       scale: null,
       xScale: null,
       yScale: null,
       colorScale: null,
-      margin: {
-        left: 0,
-        right: 0,
-        top: 0,
-        bottom: 0,
-      },
     };
   },
 
   watch: {
     chartData: {
-      deep: true,
-      handler() {
-        this.destroyChart();
-        this.renderChart();
+      handler(newData, oldData) {
+        if (!_.isEqual(newData, oldData)) {
+          this.doRerender();
+        }
       },
     },
   },
 
-  mounted() {
-    this.$nextTick(() => {
-      this.margin.top = this.marginAll;
-      this.margin.bottom = this.marginAll;
-      this.margin.left = this.marginAll;
-      this.margin.right = this.marginAll;
-
-      this.destroyChart();
-      this.renderChart();
-    });
-
-    window.addEventListener(
-      'resize',
-      _.debounce(() => {
-        this.destroyChart();
-        this.renderChart();
-      }, 1500),
-    );
-  },
-
-  beforeDestroy() {
-    window.removeEventListener('resize', _.noop);
-  },
-
-  computed: {},
-
   methods: {
-    getWidth(): number {
-      return +d3.select(`#${this.chartId}`).style('width').slice(0, -2) || 0;
-    },
-
-    getHeight(): number {
-      return +d3.select(`#${this.chartId}`).style('height').slice(0, -2) || 0;
-    },
-
-    getInnerWidth(): number {
-      return this.getWidth() - this.margin.left - this.margin.right;
-    },
-
-    getInnerHeight(): number {
-      return this.getHeight() - this.margin.top - this.margin.bottom;
-    },
-
     getInnerRadius(): number {
       return Math.min(this.getInnerWidth(), this.getInnerHeight()) / 2;
     },
 
     getFontSize(): number {
       return Math.min(this.getInnerWidth(), this.getInnerHeight()) * 0.065;
-    },
-
-    destroyChart() {
-      d3.select(`#${this.chartId} svg`).remove();
     },
 
     renderChart() {

--- a/src/mixins/d3BaseChart.js
+++ b/src/mixins/d3BaseChart.js
@@ -30,17 +30,39 @@ export const D3BaseChartMixin = {
       svg: null,
       x: null,
       y: null,
+      resizeObserver: null,
     };
   },
 
   mounted() {
     this.d3 = require('d3');
-    this.$nextTick(this.doRerender);
-    window.addEventListener('resize', this.doRerender);
+    this.$nextTick(() => {
+      /**
+       * ResizeObserver to rerender chart
+       * when dimensions of chart's parent container changes
+       *
+       * @see https://developer.mozilla.org/en-US/docs/Web/API/Resize_Observer_API
+       */
+
+      this.resizeObserver = new ResizeObserver(
+        _.debounce(() => {
+          this.margin.top = this.marginAll;
+          this.margin.bottom = this.marginAll;
+          this.margin.left = this.marginAll;
+          this.margin.right = this.marginAll;
+
+          this.destroyChart();
+          this.renderChart();
+          console.log('rerender', this.chartId);
+        }, 1500),
+      );
+
+      this.resizeObserver.observe(document.querySelector(`#${this.chartId}`));
+    });
   },
 
   beforeDestroy() {
-    window.removeEventListener('resize', this.doRerender);
+    this.resizeObserver.disconnect();
   },
 
   methods: {

--- a/src/mixins/d3BaseChart.js
+++ b/src/mixins/d3BaseChart.js
@@ -44,7 +44,7 @@ export const D3BaseChartMixin = {
   },
 
   methods: {
-    doRerender: _.debounce(() => {
+    doRerender: _.debounce(function () {
       this.margin.top = this.marginAll;
       this.margin.bottom = this.marginAll;
       this.margin.left = this.marginAll;

--- a/src/mixins/d3BaseChart.js
+++ b/src/mixins/d3BaseChart.js
@@ -35,7 +35,16 @@ export const D3BaseChartMixin = {
 
   mounted() {
     this.d3 = require('d3');
-    this.$nextTick(() => {
+    this.$nextTick(this.doRerender);
+    window.addEventListener('resize', this.doRerender);
+  },
+
+  beforeDestroy() {
+    window.removeEventListener('resize', this.doRerender);
+  },
+
+  methods: {
+    doRerender: _.debounce(() => {
       this.margin.top = this.marginAll;
       this.margin.bottom = this.marginAll;
       this.margin.left = this.marginAll;
@@ -43,22 +52,8 @@ export const D3BaseChartMixin = {
 
       this.destroyChart();
       this.renderChart();
-    });
+    }, 1500),
 
-    window.addEventListener(
-      'resize',
-      _.debounce(() => {
-        this.destroyChart();
-        this.renderChart();
-      }, 1500),
-    );
-  },
-
-  beforeDestroy() {
-    window.removeEventListener('resize', _.noop);
-  },
-
-  methods: {
     getWidth() {
       // eslint-disable-next-line no-undef
       return (

--- a/src/mixins/d3BaseChart.js
+++ b/src/mixins/d3BaseChart.js
@@ -55,17 +55,19 @@ export const D3BaseChartMixin = {
     }, 1500),
 
     getWidth() {
-      // eslint-disable-next-line no-undef
-      return (
-        +this.d3.select(`#${this.chartId}`).style('width').slice(0, -2) || 0
-      );
+      const chartContainer = this.d3.select(`#${this.chartId}`);
+      if (chartContainer) {
+        return +chartContainer.style('width').slice(0, -2) || 0;
+      }
+      return 0;
     },
 
     getHeight() {
-      // eslint-disable-next-line no-undef
-      return (
-        +this.d3.select(`#${this.chartId}`).style('height').slice(0, -2) || 0
-      );
+      const chartContainer = this.d3.select(`#${this.chartId}`);
+      if (chartContainer) {
+        return +chartContainer.style('height').slice(0, -2) || 0;
+      }
+      return 0;
     },
 
     getInnerWidth() {

--- a/src/mixins/d3BaseChart.js
+++ b/src/mixins/d3BaseChart.js
@@ -12,7 +12,7 @@ export const D3BaseChartMixin = {
     /**
      * top, bottom, left, right margins
      */
-    marginAll: VueTypes.number.def(5),
+    marginAll: VueTypes.number.def(20),
     /**
      * background color / gradient
      */

--- a/src/pages/unauthenticated/PewPew.vue
+++ b/src/pages/unauthenticated/PewPew.vue
@@ -940,7 +940,7 @@ export default {
     },
     // timer handler functions for circulating through d3 charts
     startTabCirculationTimer(ms) {
-      const totalTabs = 4; // total tabs present inside tabs component
+      const totalTabs = 3; // total tabs present inside tabs component
       this.chartCirculationTimerData.timerId = setInterval(() => {
         this.chartCirculationTimerData.activeChartTab =
           (this.chartCirculationTimerData.activeChartTab + 1) % totalTabs;

--- a/src/pages/unauthenticated/PewPew.vue
+++ b/src/pages/unauthenticated/PewPew.vue
@@ -574,6 +574,7 @@
                         completedCases: slotProps.item.closed_count || 0,
                       }"
                       :bg-color="styles.backgroundColor"
+                      :margin-all="5"
                     />
                   </div>
                 </template>


### PR DESCRIPTION
- fix(mixins): handle window resize event listener efficiently
- fix(mixins): add null guards in getWidth & getHeight funcs
- fix(mixins): fix doRerender function context in `d3BaseChart`
- fix(comp/charts): refactor `CircularBarplot` by utilizing `D3BaseChartMixin`
- fix(comp/charts): replace VueType shape with object to fix unnecessary prop validation errors in console
- fix(comp/charts): refactor `D3BarChart` by utilizing `D3BaseChartMixin` + refactor funcs
- feat(mixins): increase default marginAll prop
- refactor(comp/charts): refactor chartData watcher + change BarChartT type
- fix(comp/charts): fix path transition errors for `CircularBarplot`
- fix(comp/charts): fix `CaseDonutChart` infinite watcher rendering issue + utilize `D3BaseChartMixin`
- feat(pewpew): change marginAll prop for `CaseDonutChart`
- fix(pewpew): fix totalTabs number for chart tabs rotation
- refactor(comp/charts): refactor `SiteActivityGauge` by utilizing `D3BaseChartMixin`
- feat(mixins): utilize `ResizeObserver` instead of window resize event listener to handle chart rerenders efficiently
