### PR TITLE
Issue #1284. Temporarily hide more stats link.

### DIFF
--- a/src/pages/unauthenticated/PewPew.vue
+++ b/src/pages/unauthenticated/PewPew.vue
@@ -131,9 +131,11 @@
                       </div>
                     </template>
                   </div>
+                  <!-- Add future statistics stub
                   <div class="underline text-blue-600">
                     {{ $t('reports.pp_site_stats_more_stats') }}
                   </div>
+                  -->
                 </div>
               </div>
             </tab>


### PR DESCRIPTION
Ross mentioned commenting the `div` for now because more stats are going to be added in the future and wanted to keep the block as a placeholder.