### PR TITLE
fix(text): add curly for translation

### DIFF
--- a/src/components/phone/ActiveCall.vue
+++ b/src/components/phone/ActiveCall.vue
@@ -73,7 +73,10 @@
             size="xl"
             class="pb-1"
           />
-          <base-text variant="h3" class="text-crisiscleanup-dark-400"
+          <base-text
+            variant="h3"
+            class="text-crisiscleanup-dark-400"
+            :style="$mq === 'sm' ? '' : 'margin-top: 16px;'"
             >{{ $t('~~New Case') }}
           </base-text>
         </div>

--- a/src/components/phone/ActiveCall.vue
+++ b/src/components/phone/ActiveCall.vue
@@ -77,7 +77,7 @@
             variant="h3"
             class="text-crisiscleanup-dark-400"
             :style="$mq === 'sm' ? '' : 'margin-top: 16px;'"
-            >{{ $t('~~New Case') }}
+            >{{ $t('phoneDashboard.new_case') }}
           </base-text>
         </div>
       </div>

--- a/src/components/phone/UpdateStatus.vue
+++ b/src/components/phone/UpdateStatus.vue
@@ -14,7 +14,7 @@
       <div v-for="(section, index) in sortedValues" :key="index">
         <div>
           <div class="font-bold">
-            {{ $t(`~~${section.name}`) }}
+            {{ section.name }}
           </div>
           <div v-for="(item, idx) in section.values" :key="idx">
             <div

--- a/src/components/phone/UpdateStatus.vue
+++ b/src/components/phone/UpdateStatus.vue
@@ -14,7 +14,7 @@
       <div v-for="(section, index) in sortedValues" :key="index">
         <div>
           <div class="font-bold">
-            {{ section.name }}
+            {{ $t(`~${section.name}`) }}
           </div>
           <div v-for="(item, idx) in section.values" :key="idx">
             <div
@@ -23,7 +23,7 @@
               :style="`background: ${section.color}`"
               @click="status = item.value"
             >
-              {{ item.name_t }}
+              {{ $t(`~${item.name_t}`) }}
             </div>
           </div>
         </div>

--- a/src/components/phone/UpdateStatus.vue
+++ b/src/components/phone/UpdateStatus.vue
@@ -14,7 +14,7 @@
       <div v-for="(section, index) in sortedValues" :key="index">
         <div>
           <div class="font-bold">
-            {{ $t(`~${section.name}`) }}
+            {{ $t(`~~${section.name}`) }}
           </div>
           <div v-for="(item, idx) in section.values" :key="idx">
             <div
@@ -23,7 +23,7 @@
               :style="`background: ${section.color}`"
               @click="status = item.value"
             >
-              {{ $t(`~${item.name_t}`) }}
+              {{ $t(`~~${item.name_t}`) }}
             </div>
           </div>
         </div>

--- a/src/components/phone/UpdateStatus.vue
+++ b/src/components/phone/UpdateStatus.vue
@@ -23,7 +23,7 @@
               :style="`background: ${section.color}`"
               @click="status = item.value"
             >
-              {{ $t(`~~${item.name_t}`) }}
+              {{ $t(item.name_t) }}
             </div>
           </div>
         </div>


### PR DESCRIPTION
This PR fixes issues on newly added text to have '~~' before text for translation.

![2022-06-01 (1)](https://user-images.githubusercontent.com/47184160/171467903-426d1de8-8c1a-42bd-9051-1493b7a3236b.png)
![2022-06-01](https://user-images.githubusercontent.com/47184160/171467907-ea9e5f0d-4e69-451a-a418-ac8b5f1cd173.png)
