### PR TITLE
 fix(pewpewnavbar): make the text white and no underline

### DIFF
--- a/src/components/navigation/PewPewNavBar.vue
+++ b/src/components/navigation/PewPewNavBar.vue
@@ -23,13 +23,13 @@
         :href="r.route"
         target="_blank"
       >
-        <div class="pewpew__navlink">
+        <div class="pewpew__navlink text-white">
           <ccu-icon :linked="true" v-bind="r.iconProps" />
           {{ r.title }}
         </div>
       </a>
       <router-link v-else :key="r.title" :to="r.routeProps">
-        <div class="pewpew__navlink">
+        <div class="pewpew__navlink text-white">
           <ccu-icon :linked="true" v-bind="r.iconProps" />
           {{ r.title }}
         </div>
@@ -145,6 +145,9 @@ export default {
 };
 </script>
 <style lang="postcss">
+a {
+  text-decoration: none !important;
+}
 .pewpew {
   &__nav {
     @apply col-span-2 flex flex-col text-xs text-center break-words;

--- a/src/components/navigation/PewPewNavBar.vue
+++ b/src/components/navigation/PewPewNavBar.vue
@@ -29,7 +29,7 @@
         </div>
       </a>
       <router-link v-else :key="r.title" :to="r.routeProps">
-        <div class="pewpew__navlink text-white">
+        <div class="pewpew__navlink">
           <ccu-icon :linked="true" v-bind="r.iconProps" />
           {{ r.title }}
         </div>
@@ -144,11 +144,16 @@ export default {
   },
 };
 </script>
-<style lang="postcss">
+<style lang="scss">
 .pewpew {
   &__nav {
-    @apply col-span-2 flex flex-col text-xs text-center break-words text-white no-underline;
+    @apply col-span-2 flex flex-col text-xs text-center break-words no-underline;
+    color: white;
     background: #242c36;
+
+    a {
+      @apply no-underline;
+    }
   }
 
   &__navheader {
@@ -160,7 +165,8 @@ export default {
   }
 
   &__navlink {
-    @apply flex flex-col justify-center items-center m-1 p-2 rounded-lg text-white;
+    @apply flex flex-col justify-center items-center m-1 p-2 rounded-lg;
+    color: white;
     /** this is against accessiblity standards. */
     font-size: 0.55rem;
     transition: background-color 300ms;

--- a/src/components/navigation/PewPewNavBar.vue
+++ b/src/components/navigation/PewPewNavBar.vue
@@ -23,7 +23,7 @@
         :href="r.route"
         target="_blank"
       >
-        <div class="pewpew__navlink text-white">
+        <div class="pewpew__navlink">
           <ccu-icon :linked="true" v-bind="r.iconProps" />
           {{ r.title }}
         </div>
@@ -145,12 +145,9 @@ export default {
 };
 </script>
 <style lang="postcss">
-a {
-  text-decoration: none !important;
-}
 .pewpew {
   &__nav {
-    @apply col-span-2 flex flex-col text-xs text-center break-words;
+    @apply col-span-2 flex flex-col text-xs text-center break-words text-white no-underline;
     background: #242c36;
   }
 
@@ -163,7 +160,7 @@ a {
   }
 
   &__navlink {
-    @apply flex flex-col justify-center items-center m-1 p-2 rounded-lg;
+    @apply flex flex-col justify-center items-center m-1 p-2 rounded-lg text-white;
     /** this is against accessiblity standards. */
     font-size: 0.55rem;
     transition: background-color 300ms;

--- a/src/pages/home/RegisterOrganization.vue
+++ b/src/pages/home/RegisterOrganization.vue
@@ -370,7 +370,7 @@ export default {
 }
 </style>
 
-<style>
+<style lang="scss" scoped>
 .privacy > a {
   @apply text-primary-dark;
   text-decoration: underline !important;

--- a/src/pages/unauthenticated/PewPew.vue
+++ b/src/pages/unauthenticated/PewPew.vue
@@ -2003,7 +2003,8 @@ export default {
 }
 
 .live-tab {
-  @apply flex items-center justify-center h-12 cursor-pointer;
+  @apply flex items-center justify-center h-12 cursor-pointer text-white no-underline;
+  text-decoration: none !important;
 }
 
 .live-tab--selected {

--- a/src/pages/unauthenticated/Survivors.vue
+++ b/src/pages/unauthenticated/Survivors.vue
@@ -628,7 +628,7 @@ export default {
 }
 </style>
 
-<style>
+<style lang="scss" scoped>
 a {
   @apply text-primary-dark;
   text-decoration: underline !important;


### PR DESCRIPTION
Before
![974cab31e68444b3ad314c913a672668](https://user-images.githubusercontent.com/47184160/192304741-37f67a48-4671-4c22-8d6c-f0bba12a0336.png)
![01a7a528ec612514598fff9f72eda6ce](https://user-images.githubusercontent.com/47184160/192304745-84e70cea-4547-49b0-ae5b-99805bee0012.png)


After
Changed the a tags on the nav bar to be white and without the underline

![db83882382470201dded4dd77f392f13](https://user-images.githubusercontent.com/47184160/192305117-9496f728-0cab-48f8-a728-a3ff0918163c.png)
![00c73c78dc4b37f91362a13e1d2348ce](https://user-images.githubusercontent.com/47184160/192305118-0a3cf2b0-23da-4842-bfeb-b03cc83b3a56.png)

