### PR TITLE
Fix, improve, refactor phone system components for stability

### DIFF
--- a/src/components/cards/TabbedCard.vue
+++ b/src/components/cards/TabbedCard.vue
@@ -77,14 +77,14 @@ export default {
     bottom: 0;
     width: 100%;
     display: inline-block;
-    transition: transform 300ms easeInOutCirc;
+    transition: transform 300ms ease-in-out;
   }
 
   &__tab {
     @apply py-4 px-6 text-crisiscleanup-dark-400;
     position: relative;
     cursor: pointer;
-    transition: opacity 300ms easeInOutCirc;
+    transition: opacity 300ms ease-in-out;
     opacity: 0.5;
     &:hover,
     &.active {

--- a/src/components/chat/Chat.vue
+++ b/src/components/chat/Chat.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex-1 p:2 sm:p-6 flex flex-col w-full">
+  <div class="flex-1 p-2 sm:p-3 flex flex-col w-full">
     <div class="flex sm:items-center py-1 border-b border-gray-200">
       <div class="text-lg">{{ chat.name }}</div>
     </div>
@@ -292,6 +292,6 @@ export default {
 }
 .message-container {
   @apply flex flex-col;
-  height: 65vh;
+  height: 60vh;
 }
 </style>

--- a/src/components/phone/PhoneComponentButton.vue
+++ b/src/components/phone/PhoneComponentButton.vue
@@ -1,8 +1,10 @@
 <template>
   <div>
     <div
-      class="w-full h-full z-40"
-      :class="showComponent ? 'bg-gray-200' : ''"
+      class="w-full h-full cursor-pointer z-40"
+      :class="
+        showComponent ? 'bg-gray-100 border-l-2 border-l-primary-light' : ''
+      "
       @click="toggleComponent"
     >
       <slot name="button">
@@ -17,7 +19,7 @@
       </slot>
     </div>
     <div
-      class="phone-component absolute top-10 ml-12 z-30"
+      class="phone-component absolute top-1 mr-1 z-30"
       :class="componentClass"
       :style="componentStyle"
       v-show="showComponent"
@@ -27,17 +29,11 @@
           :alt="$t('actions.cancel')"
           size="xs"
           type="cancel"
-          class="absolute right-0 p-2"
-          @click.native="
-            () => {
-              showComponent = false;
-            }
-          "
+          class="absolute right-0 p-2 cursor-pointer"
+          @click.native="() => (showComponent = false)"
         />
       </div>
-      <div class="mt-10 sm:mt-0">
-        <slot name="component"></slot>
-      </div>
+      <slot name="component"></slot>
     </div>
   </div>
 </template>
@@ -103,20 +99,8 @@ export default {
 
 <style lang="scss" scoped>
 .phone-component {
-  transform: translateY(-3rem);
+  @apply shadow-lg bg-white overflow-auto;
   min-height: 10vh;
-  height: 90%;
-  @apply shadow-lg bg-white sm:mt-12 overflow-auto;
-}
-@media (max-width: 640px) {
-  .phone-component {
-    width: 87vw;
-    margin-left: -87vw;
-  }
-}
-@media only screen and (max-device-width: 1223px) and (orientation: landscape) {
-  .phone-component {
-    @apply mt-16;
-  }
+  height: 100%;
 }
 </style>

--- a/src/components/phone/PhoneComponentButton.vue
+++ b/src/components/phone/PhoneComponentButton.vue
@@ -111,7 +111,6 @@ export default {
     absolute top-1 mr-1 z-30
     overflow-auto;
     min-height: 10vh;
-    height: 100%;
   }
 
   &__icon {

--- a/src/components/phone/PhoneComponentButton.vue
+++ b/src/components/phone/PhoneComponentButton.vue
@@ -1,14 +1,12 @@
 <template>
-  <div>
+  <div class="phone-system-action">
     <div
-      class="w-full h-full cursor-pointer z-40"
-      :class="
-        showComponent ? 'bg-gray-100 border-l-2 border-l-primary-light' : ''
-      "
+      class="phone-system-action__button"
+      :class="showComponent ? 'phone-system-action__button--active' : ''"
       @click="toggleComponent"
     >
       <slot name="button">
-        <div class="w-full h-full flex items-center justify-center">
+        <div class="phone-system-action__icon">
           <ccu-icon
             v-if="icon"
             :type="icon"
@@ -19,17 +17,17 @@
       </slot>
     </div>
     <div
-      class="phone-component absolute top-1 mr-1 z-30"
+      class="phone-system-action__content"
       :class="componentClass"
       :style="componentStyle"
       v-show="showComponent"
     >
-      <div class="w-full relative mb-2 z-40">
+      <div class="phone-system-action__close">
         <ccu-icon
           :alt="$t('actions.cancel')"
           size="xs"
           type="cancel"
-          class="absolute right-0 p-2 cursor-pointer"
+          class="phone-system-action__close-icon"
           @click.native="() => (showComponent = false)"
         />
       </div>
@@ -97,10 +95,34 @@ export default {
 };
 </script>
 
-<style lang="scss" scoped>
-.phone-component {
-  @apply shadow-lg bg-white overflow-auto;
-  min-height: 10vh;
-  height: 100%;
+<style lang="postcss" scoped>
+.phone-system-action {
+  &__button {
+    @apply w-full h-full cursor-pointer z-40;
+    &--active {
+      @apply bg-gray-100 border-l-2 border-l-primary-light;
+    }
+  }
+
+  &__content {
+    @apply shadow-lg
+    bg-white
+    shadow-md
+    absolute top-1 mr-1 z-30
+    overflow-auto;
+    min-height: 10vh;
+    height: 100%;
+  }
+
+  &__icon {
+    @apply w-full h-full flex items-center justify-center;
+  }
+
+  &__close {
+    @apply w-full relative mb-2 z-40;
+    &-icon {
+      @apply absolute right-0 p-2 cursor-pointer;
+    }
+  }
 }
 </style>

--- a/src/pages/CaseForm.vue
+++ b/src/pages/CaseForm.vue
@@ -1296,7 +1296,7 @@ export default {
 };
 </script>
 
-<style lang="scss" scoped>
+<style lang="postcss" scoped>
 .case-form {
   /* flex-grow needed to take full space from parent */
   @apply bg-white
@@ -1342,17 +1342,5 @@ export default {
   .case-form {
     bottom: env(safe-area-inset-bottom, 30px);
   }
-}
-
-@media (max-width: 640px) {
-}
-h4 {
-  font-size: 16px;
-  font-weight: bold;
-}
-
-h5 {
-  font-size: 14px;
-  font-weight: bold;
 }
 </style>

--- a/src/pages/CaseForm.vue
+++ b/src/pages/CaseForm.vue
@@ -1323,7 +1323,7 @@ export default {
   }
 
   &__actions {
-    @apply text-black w-full;
+    @apply text-black w-full sm:py-2;
     &--cancel {
       @apply border-2 border-black;
     }

--- a/src/pages/CaseForm.vue
+++ b/src/pages/CaseForm.vue
@@ -3,10 +3,8 @@
     class="case-form case-form__container"
     v-if="ready"
     ref="form"
-    :class="noGrid && 'no-grid'"
     @submit.prevent
   >
-    <!--    :style="formStyle"-->
     <div class="case-form__header">
       <!-- maybe not required -->
       <!-- <resize-observer @notify="calcFormStyle" /> -->
@@ -491,17 +489,6 @@ export default {
       type: Object,
       default: () => ({}),
     },
-    resizeMethod: {
-      // one of:
-      // parent: resize based on intake container.
-      // screen: resize based on scrollable screen.
-      type: String,
-      default: 'parent',
-    },
-    noGrid: {
-      type: Boolean,
-      default: false,
-    },
   },
   data() {
     return {
@@ -526,7 +513,6 @@ export default {
       sectionCounter: 2,
       addAdditionalPhone: false,
       currentNote: '',
-      formStyle: {},
       hideDetailedAddressFields: true,
       addressSet: false,
     };
@@ -1266,21 +1252,6 @@ export default {
     },
     logFormdata() {
       this.$log.debug(new FormData(this.$refs.form));
-    },
-    calcFormStyle() {
-      if (!this.$refs.form) return;
-      if (this.resizeMethod === 'none' || this.resizeMethod === null) return;
-      const topOffset = this.$refs.form.offsetTop;
-      let parentHeight = this.$refs.form.offsetParent.clientHeight;
-      if (this.resizeMethod === 'screen') {
-        parentHeight = window.screen.availHeight;
-      }
-      const formHeight = parentHeight - topOffset;
-      this.formStyle = {
-        'grid-template-rows': `calc(${
-          formHeight - 80
-        }px - var(--safe-area-inset-bottom)) 80px`,
-      };
     },
   },
   watch: {

--- a/src/pages/CaseForm.vue
+++ b/src/pages/CaseForm.vue
@@ -1,14 +1,17 @@
 <template>
   <form
+    class="case-form case-form__container"
     v-if="ready"
     ref="form"
-    class="bg-white flex flex-col flex-grow w-full intake-form-container"
     :class="noGrid && 'no-grid'"
     @submit.prevent
-    :style="formStyle"
   >
-    <resize-observer @notify="calcFormStyle" />
-    <div class="intake-form" :class="(noGrid || $mq === 'sm') && 'no-grid'">
+    <!--    :style="formStyle"-->
+    <div class="case-form__header">
+      <!-- maybe not required -->
+      <!-- <resize-observer @notify="calcFormStyle" /> -->
+    </div>
+    <div class="case-form__body">
       <SectionHeading :count="1" class="mb-3">{{
         $t('caseForm.property_information')
       }}</SectionHeading>
@@ -371,10 +374,10 @@
         />
       </template>
     </div>
-    <div class="card-footer">
+    <div class="case-form__footer">
       <base-button
         size="medium"
-        class="flex-grow m-1 border-2 border-black"
+        class="case-form__actions case-form__actions--cancel"
         variant="text"
         :action="
           () => {
@@ -388,7 +391,7 @@
         size="medium"
         variant="solid"
         data-cy="worksite-formaction-save"
-        class="flex-grow m-1 text-black"
+        class="case-form__actions case-form__actions--save"
         :action="saveWorksite"
         :text="$t('actions.save')"
       />
@@ -396,7 +399,7 @@
         v-if="!disableClaimAndSave"
         size="medium"
         variant="solid"
-        class="flex-grow m-1 text-black"
+        class="case-form__actions case-form__actions--save-claim"
         :action="claimAndSaveWorksite"
         :text="$t('actions.save_claim')"
       />
@@ -1294,58 +1297,55 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.ant-form-item {
-  padding-top: 10px;
-  margin: 0;
-}
+.case-form {
+  /* flex-grow needed to take full space from parent */
+  @apply bg-white
+    flex-grow
+    flex
+    flex-col
+    w-full
+    absolute
+    top-0
+    left-0
+    right-0
+    bottom-16 /* don't let buttons hide under url bar on some mobile browsers */
+    sm:bottom-0;
 
-.intake-form-container {
-  --safe-area-inset-bottom: env(safe-area-inset-bottom);
-  grid-template-columns: 1fr;
-  grid-template-rows: calc(100vh - 240px - var(--safe-area-inset-bottom));
-  display: grid;
-  &.no-grid {
-    display: inherit;
+  &__header {
   }
-}
 
-.intake-form {
-  height: 100%;
-  overflow: auto;
+  &__body {
+    @apply flex-1 overflow-auto;
+  }
+
+  &__footer {
+    @apply flex justify-between p-3 gap-2;
+  }
+
+  &__actions {
+    @apply text-black w-full;
+    &--cancel {
+      @apply border-2 border-black;
+    }
+    &--save {
+    }
+    &--claim-save {
+    }
+  }
+
+  .form-field {
+    @apply py-1 mx-3;
+  }
 }
 
 @media only screen and (max-device-width: 1223px) and (orientation: landscape) {
-  .intake-form {
-    height: 145%;
+  .case-form {
+    bottom: env(safe-area-inset-bottom, 30px);
   }
-}
-
-.card-footer {
-  @apply bg-white
-      p-3
-      border border-r-0 border-gray-300
-      flex
-      justify-between
-      fixed
-      bottom-0;
-  min-height: 5rem;
-  width: 21rem;
 }
 
 @media (max-width: 640px) {
-  .intake-form {
-    height: 75%;
-  }
-
-  .card-footer {
-    width: 100%;
-  }
 }
-
-.form-field {
-  @apply py-1 mx-3;
-}
-
 h4 {
   font-size: 16px;
   font-weight: bold;

--- a/src/pages/Cases.vue
+++ b/src/pages/Cases.vue
@@ -1033,9 +1033,13 @@
           />
         </template>
       </div>
-      <div class="relative" style="height: 95%" v-if="!spinning">
+      <div
+        class="relative h-full"
+        :class="$mq === 'sm' ? 'flex flex-col' : ''"
+        v-if="!spinning"
+      >
         <div
-          :class="$mq == 'sm' ? 'mt-2 ml-14 bg-white fixed search-input' : ''"
+          :class="$mq === 'sm' ? 'mt-2 ml-14 bg-white fixed search-input' : ''"
         >
           <WorksiteSearchInput
             v-if="$mq === 'sm'"
@@ -1067,33 +1071,35 @@
           @onSelectmarker="displayWorksite"
           @onLoadedMarkers="onLoadedMarkers"
         />
-        <router-view
-          :key="$route.params.id"
-          :incident-id="`${currentIncidentId}`"
-          :worksite-id="$route.params.id"
-          :incident="currentIncident"
-          :is-editing="isEditingWorksite"
-          @closeWorksite="closeWorksite"
-          @clearWorksite="clearWorksite"
-          @geocoded="addMarkerToMap"
-          @clearMarkers="removeMarkerFromMap"
-          @savedWorksite="savedWorksite"
-          @switchIncident="switchIncident"
-          @navigateToWorksite="
-            (id) => {
-              $router.push(
-                `/incident/${currentIncidentId}/cases/${id}/edit?showOnMap=true`,
-              );
-            }
-          "
-          @reloadTable="reloadTable"
-          @changed="loadWorksite"
-          @reloadMap="reloadMap"
-          @jumpToCase="jumpToCase"
-          @image-click="showImage"
-          @changeImg="changeImage"
-          ref="cases"
-        />
+        <div class="relative h-full">
+          <router-view
+            :key="$route.params.id"
+            :incident-id="`${currentIncidentId}`"
+            :worksite-id="$route.params.id"
+            :incident="currentIncident"
+            :is-editing="isEditingWorksite"
+            @closeWorksite="closeWorksite"
+            @clearWorksite="clearWorksite"
+            @geocoded="addMarkerToMap"
+            @clearMarkers="removeMarkerFromMap"
+            @savedWorksite="savedWorksite"
+            @switchIncident="switchIncident"
+            @navigateToWorksite="
+              (id) => {
+                $router.push(
+                  `/incident/${currentIncidentId}/cases/${id}/edit?showOnMap=true`,
+                );
+              }
+            "
+            @reloadTable="reloadTable"
+            @changed="loadWorksite"
+            @reloadMap="reloadMap"
+            @jumpToCase="jumpToCase"
+            @image-click="showImage"
+            @changeImg="changeImage"
+            ref="cases"
+          />
+        </div>
       </div>
       <div v-else class="h-full w-full items-center justify-center">
         <div class="flex flex-col items-center">

--- a/src/pages/phone/PhoneSystem.vue
+++ b/src/pages/phone/PhoneSystem.vue
@@ -290,7 +290,6 @@
                   v-if="selectedChat"
                   @unreadCount="unreadChatCount = $event"
                   @unreadUrgentCount="unreadUrgentChatCount = $event"
-                  class="h-full"
                   @onNewMessage="unreadChatCount += 1"
                   @onNewUrgentMessage="unreadUrgentChatCount += 1"
                   :chat="selectedChat"
@@ -1011,7 +1010,7 @@ export default {
       &--chat {
       }
       &--news {
-        @apply h-full;
+        height: 60vh;
         width: 50vw;
       }
       &--history {
@@ -1021,7 +1020,7 @@ export default {
       &--stats {
       }
       &--leaderboard {
-        @apply h-full;
+        height: 60vh;
         width: 50vw;
       }
       &--reset {

--- a/src/pages/phone/PhoneSystem.vue
+++ b/src/pages/phone/PhoneSystem.vue
@@ -1,8 +1,6 @@
 <template>
-  <div
-    class="flex-grow h-full"
-    :class="$mq === 'sm' ? 'page-grid-mobile' : 'page-grid'"
-  >
+  <div class="phone-system">
+    <!-- TODO: Move this (doesn't belong here) -->
     <div class="modal" v-if="showImgModal">
       <div class="modal-content">
         <font-awesome-icon
@@ -101,8 +99,8 @@
         />
       </div>
     </div>
-    <div class="flex flex-col" :class="$mq === 'sm' ? 'h-1/3' : ''">
-      <div class="flex items-center">
+    <div class="phone-system__main">
+      <div class="phone-system__main-header">
         <div class="flex py-3 px-2" style="min-width: 80px">
           <ccu-icon
             :alt="$t('casesVue.map_view')"
@@ -173,14 +171,14 @@
         :select-case="selectCase"
         :worksite-id="worksiteId"
       />
-      <div class="flex-grow">
-        <div v-show="showingMap" class="relative h-full select-none">
+      <div class="phone-system__main-content">
+        <div v-show="showingMap" class="phone-system__main-content--map">
           <PhoneMap :map-loading="mapLoading" />
           <div class="phone-system__actions" ref="phoneButtons">
             <PhoneComponentButton
               v-show="caller"
               name="caller"
-              class="phone-button"
+              class="phone-system__action--caller"
               component-class="right-12 h-auto"
               component-style="width: 30rem;"
             >
@@ -204,7 +202,7 @@
             </PhoneComponentButton>
             <PhoneComponentButton
               name="dialer"
-              class="phone-button"
+              class="phone-system__action"
               component-class="right-12"
               component-style="width: 30rem;"
               icon="dialer"
@@ -222,7 +220,7 @@
             </PhoneComponentButton>
             <PhoneComponentButton
               name="chat"
-              class="phone-button"
+              class="phone-system__action"
               component-class="right-12 h-auto"
               component-style="width: 30rem; height: auto;"
               @open="
@@ -304,7 +302,7 @@
             </PhoneComponentButton>
             <PhoneComponentButton
               name="news"
-              class="phone-button"
+              class="phone-system__action"
               component-class="right-12 h-auto"
               component-style="width: 50rem;"
               @open="
@@ -354,14 +352,14 @@
               </template>
             </PhoneComponentButton>
             <PhoneComponentButton
+              v-if="callHistory"
               name="history"
-              class="phone-button"
+              class="phone-system__action"
               component-class="right-12 h-auto"
               component-style="width: 50rem;"
               icon="phone-history"
               icon-size="large"
               icon-class="p-1"
-              v-if="callHistory"
             >
               <template v-slot:component>
                 <CallHistory
@@ -376,7 +374,7 @@
             </PhoneComponentButton>
             <PhoneComponentButton
               name="stats"
-              class="phone-button"
+              class="phone-system__action"
               component-class="right-12 h-auto"
               component-style="width: 30rem;"
             >
@@ -396,7 +394,7 @@
             </PhoneComponentButton>
             <PhoneComponentButton
               name="leaderboard"
-              class="phone-button"
+              class="phone-system__action"
               component-class="right-12 h-auto"
               component-style="width: 50rem;"
               icon="leaderboard"
@@ -414,7 +412,7 @@
             </PhoneComponentButton>
             <PhoneComponentButton
               name="reset"
-              class="phone-button"
+              class="phone-system__action"
               component-class="right-12 h-auto"
               component-style="width: 30rem;"
               icon="logout"
@@ -434,7 +432,7 @@
             </PhoneComponentButton>
           </div>
         </div>
-        <div v-show="showingTable" class="p-2 h-full shadow">
+        <div v-show="showingTable" class="phone-system__main-content--table">
           <AjaxTable
             :columns="columns"
             :url="tableUrl"
@@ -473,15 +471,7 @@
         </div>
       </div>
     </div>
-    <PhoneToolBar
-      v-if="false"
-      :complete-call="completeCall"
-      :on-logged-in="onLoggedIn"
-      :on-toggle-outbounds="onToggleOutbounds"
-      :select-case="selectCase"
-      :worksite-id="worksiteId"
-    />
-    <div class="flex flex-col" :class="$mq === 'sm' ? 'h-2/3' : ''">
+    <div class="phone-system__form">
       <CaseHeader
         v-if="worksite"
         :worksite="worksite"
@@ -493,7 +483,7 @@
         @onPrintWorksite="() => {}"
         @onShowHistory="showHistory = true"
       />
-      <div v-else class="h-12 px-2 border flex items-center justify-between">
+      <div v-else class="phone-system__form-header">
         <div class="flex items-center cursor-pointer">
           <ccu-icon
             :alt="$t('casesVue.new_case')"
@@ -519,7 +509,7 @@
           :text="$t('casesVue.show_map')"
         />
       </div>
-      <div v-if="showingDetails" class="flex items-center justify-between px-2">
+      <div v-if="showingDetails" class="phone-system__form-toggler">
         <base-button
           icon="arrow-left"
           :icon-size="medium"
@@ -533,7 +523,7 @@
         <span class="text-base">{{ $t('actions.history') }}</span>
         <div></div>
       </div>
-      <div class="flex-grow relative h-full flex flex-col md:flex-row">
+      <div class="phone-system__form-body">
         <CaseHistory
           v-if="showHistory"
           :incident-id="currentIncidentId"
@@ -1015,22 +1005,78 @@ export default {
 
 <style lang="postcss" scoped>
 .phone-system {
+  @apply grid flex-grow h-full;
+  grid-template-columns: auto 350px;
+
   &__actions {
     @apply absolute top-0 right-0 flex flex-col;
     z-index: 1004;
   }
+
+  &__action {
+    @apply shadow
+      w-20
+      h-20
+      sm:w-12
+      sm:h-12
+      my-2
+      sm:my-1
+      bg-white
+      cursor-pointer
+      z-50;
+  }
+
+  /* Container for map */
+  &__main {
+    @apply flex flex-col;
+
+    &-header {
+      @apply flex items-center;
+    }
+
+    &-content {
+      @apply flex-grow;
+
+      &--map {
+        @apply relative h-full select-none;
+      }
+
+      &--table {
+        @apply p-2 h-full shadow;
+      }
+    }
+  }
+
+  /* Container for case form */
+  &__form {
+    @apply flex flex-col;
+
+    &-header {
+      @apply h-12 px-2 border flex items-center justify-between;
+    }
+
+    &-toggler {
+      @apply flex items-center justify-between px-2;
+    }
+
+    &-body {
+      @apply flex-grow relative h-full flex flex-col md:flex-row;
+    }
+  }
 }
 
-.page-grid {
-  display: grid;
-  grid-template-columns: auto 350px;
-}
+/* Mobile styles */
+@media screen and (max-width: theme('screens.sm')) {
+  .phone-system {
+    @apply flex flex-col;
 
-.page-grid-mobile {
-  grid-template-columns: auto;
-}
+    &__main {
+      @apply h-1/3;
+    }
 
-.phone-button {
-  @apply shadow w-20 h-20 sm:w-12 sm:h-12 my-2 sm:my-1 bg-white cursor-pointer z-50;
+    &__form {
+      @apply h-2/3;
+    }
+  }
 }
 </style>

--- a/src/pages/phone/PhoneSystem.vue
+++ b/src/pages/phone/PhoneSystem.vue
@@ -101,7 +101,7 @@
         />
       </div>
     </div>
-    <div v-if="$mq !== 'sm'" class="flex flex-col">
+    <div class="flex flex-col" :class="$mq === 'sm' ? 'h-1/3' : ''">
       <div class="flex items-center">
         <div class="flex py-3 px-2" style="min-width: 80px">
           <ccu-icon
@@ -477,14 +477,14 @@
       </div>
     </div>
     <PhoneToolBar
-      v-else
+      v-if="false"
       :complete-call="completeCall"
       :on-logged-in="onLoggedIn"
       :on-toggle-outbounds="onToggleOutbounds"
       :select-case="selectCase"
       :worksite-id="worksiteId"
     />
-    <div class="flex flex-col">
+    <div class="flex flex-col" :class="$mq === 'sm' ? 'h-2/3' : ''">
       <CaseHeader
         v-if="worksite"
         :worksite="worksite"
@@ -533,7 +533,6 @@
             }
           "
         />
-
         <span class="text-base">{{ $t('actions.history') }}</span>
         <div></div>
       </div>

--- a/src/pages/phone/PhoneSystem.vue
+++ b/src/pages/phone/PhoneSystem.vue
@@ -654,7 +654,7 @@ import ActiveCall from '@/components/phone/ActiveCall';
 import UpdateStatus from '@/components/phone/UpdateStatus';
 
 export default {
-  name: 'PhoneSysyem',
+  name: 'PhoneSystem',
   components: {
     UpdateStatus,
     ActiveCall,

--- a/src/pages/phone/PhoneSystem.vue
+++ b/src/pages/phone/PhoneSystem.vue
@@ -572,26 +572,6 @@
           @changeImg="changeImage"
         />
       </div>
-      <div
-        v-show="$mq === 'sm' && showMobileMap"
-        class="absolute right-0 top-0 left-0 bottom-0"
-      >
-        <PhoneMap></PhoneMap>
-        <div class="absolute w-full flex items-center justify-center bottom-0">
-          <base-button
-            class="mb-12"
-            variant="solid"
-            size="lg"
-            style="z-index: 1002"
-            :text="$t('phoneDashboard.close_map')"
-            :action="
-              () => {
-                showMobileMap = false;
-              }
-            "
-          />
-        </div>
-      </div>
     </div>
   </div>
 </template>

--- a/src/pages/phone/PhoneSystem.vue
+++ b/src/pages/phone/PhoneSystem.vue
@@ -178,9 +178,8 @@
             <PhoneComponentButton
               v-show="caller"
               name="caller"
-              class="phone-system__action--caller"
-              component-class="right-12 h-auto"
-              component-style="width: 30rem;"
+              class="phone-system__action"
+              component-class="phone-system__action-content phone-system__action-content--caller"
             >
               <template v-slot:button>
                 <div class="w-full h-full relative">
@@ -203,8 +202,7 @@
             <PhoneComponentButton
               name="dialer"
               class="phone-system__action"
-              component-class="right-12"
-              component-style="width: 30rem;"
+              component-class="phone-system__action-content phone-system__action-content--dialer"
               icon="dialer"
               icon-size="small"
               icon-class="bg-black p-1"
@@ -221,8 +219,7 @@
             <PhoneComponentButton
               name="chat"
               class="phone-system__action"
-              component-class="right-12 h-auto"
-              component-style="width: 30rem; height: auto;"
+              component-class="phone-system__action-content phone-system__action-content--chat"
               @open="
                 () => {
                   updateUserState({
@@ -303,8 +300,7 @@
             <PhoneComponentButton
               name="news"
               class="phone-system__action"
-              component-class="right-12 h-auto"
-              component-style="width: 50rem;"
+              component-class="phone-system__action-content phone-system__action-content--news"
               @open="
                 () => {
                   updateUserState({
@@ -355,8 +351,7 @@
               v-if="callHistory"
               name="history"
               class="phone-system__action"
-              component-class="right-12 h-auto"
-              component-style="width: 50rem;"
+              component-class="phone-system__action-content phone-system__action-content--history"
               icon="phone-history"
               icon-size="large"
               icon-class="p-1"
@@ -375,8 +370,7 @@
             <PhoneComponentButton
               name="stats"
               class="phone-system__action"
-              component-class="right-12 h-auto"
-              component-style="width: 30rem;"
+              component-class="phone-system__action-content phone-system__action-content--stats"
             >
               <template v-slot:button>
                 <div class="w-full h-full flex items-center justify-center">
@@ -395,8 +389,7 @@
             <PhoneComponentButton
               name="leaderboard"
               class="phone-system__action"
-              component-class="right-12 h-auto"
-              component-style="width: 50rem;"
+              component-class="phone-system__action-content phone-system__action-content--leaderboard"
               icon="leaderboard"
               icon-size="medium"
               icon-class="p-1"
@@ -413,8 +406,7 @@
             <PhoneComponentButton
               name="reset"
               class="phone-system__action"
-              component-class="right-12 h-auto"
-              component-style="width: 30rem;"
+              component-class="phone-system__action-content phone-system__action-content--reset"
               icon="logout"
               icon-size="small"
               icon-class="p-1"
@@ -1002,6 +994,70 @@ export default {
   },
 };
 </script>
+
+<style lang="postcss">
+.phone-system {
+  &__action {
+    &-content {
+      @apply right-20 sm:right-12 h-auto;
+      width: 35vw;
+
+      &--caller {
+        @apply h-full;
+      }
+      &--dialer {
+        @apply h-full;
+      }
+      &--chat {
+      }
+      &--news {
+        @apply h-full;
+        width: 50vw;
+      }
+      &--history {
+        @apply h-full;
+        width: 50vw;
+      }
+      &--stats {
+      }
+      &--leaderboard {
+        @apply h-full;
+        width: 50vw;
+      }
+      &--reset {
+        @apply h-full;
+      }
+    }
+  }
+}
+
+@media screen and (max-width: theme('screens.sm')) {
+  .phone-system {
+    &__action {
+      &-content {
+        width: 80vw;
+
+        &--caller {
+        }
+        &--dialer {
+        }
+        &--chat {
+        }
+        &--news {
+        }
+        &--history {
+        }
+        &--stats {
+        }
+        &--leaderboard {
+        }
+        &--reset {
+        }
+      }
+    }
+  }
+}
+</style>
 
 <style lang="postcss" scoped>
 .phone-system {

--- a/src/pages/phone/PhoneSystem.vue
+++ b/src/pages/phone/PhoneSystem.vue
@@ -178,14 +178,11 @@
           <PhoneMap :map-loading="mapLoading" />
           <div class="phone-system__actions" ref="phoneButtons">
             <PhoneComponentButton
-              v-if="caller"
-              name="call-info"
+              v-show="caller"
+              name="caller"
               class="phone-button"
               component-class="right-12 h-auto"
               component-style="width: 30rem;"
-              icon="phone"
-              icon-size="small"
-              icon-class="bg-black p-1"
             >
               <template v-slot:button>
                 <div class="w-full h-full relative">
@@ -984,6 +981,8 @@ export default {
     caller(newValue, oldValue) {
       if (!oldValue && newValue) {
         EventBus.$emit('phone_component:close');
+        // open the active call PhoneComponentButton
+        EventBus.$emit('phone_component:open', 'caller');
       }
     },
     call(newValue, oldValue) {

--- a/src/pages/phone/PhoneSystem.vue
+++ b/src/pages/phone/PhoneSystem.vue
@@ -224,7 +224,7 @@
       :select-case="selectCase"
       :worksite-id="worksiteId"
     />
-    <div>
+    <div class="flex flex-col">
       <CaseHeader
         v-if="worksite"
         :worksite="worksite"
@@ -277,7 +277,7 @@
         <span class="text-base">{{ $t('actions.history') }}</span>
         <div></div>
       </div>
-      <div class="flex flex-col md:flex-row">
+      <div class="flex-grow relative h-full flex flex-col md:flex-row">
         <tabs
           :details="false"
           v-if="caller && $mq === 'sm'"

--- a/src/pages/phone/PhoneSystem.vue
+++ b/src/pages/phone/PhoneSystem.vue
@@ -1034,20 +1034,4 @@ export default {
 .phone-button {
   @apply shadow w-20 h-20 sm:w-12 sm:h-12 my-2 sm:my-1 bg-white cursor-pointer z-50;
 }
-.tabs {
-  width: 29rem;
-  margin-left: -29rem;
-}
-.status {
-  @apply bg-white sm:w-96 sm:-ml-96 mt-1 h-84;
-}
-@media only screen and (max-device-width: 1223px) and (orientation: landscape) {
-  .tabs {
-    width: 38rem;
-    margin-left: -38rem;
-    margin-top: -3rem;
-    height: 350px;
-    @apply overflow-auto;
-  }
-}
 </style>


### PR DESCRIPTION
<!--
Provide a general summary of your changes in the title above

NOTE: Please uncomment (Ctrl/Cmd + /) the header lines if
you have that information about the pull request
-->

<!--
- Describe your changes in detail
- What does this pull request add/fix? Explain your changes.
-->
## Description

This PR focuses on improving stability of the phone page. I have made several layout changes to avoid things from breaking. Everything on the page is now placed properly using flex, grid, relative/absolute to make it more dynamic and responsive. I have tested it well. I am confident with my changes and I am sure that I haven't broken anything on the page. This PR only includes UI changes with maybe one or two logic changes for new active call tab. We would want to test the stability of the phone page on staging first before pushing to production.

### Changes

- refactor(pages): fix typo in component name
- fix(pages): set flex-col, relative positioning, height for `CaseForm` container in `PhoneSystem`
- fix(pages): update container styles for `CaseForm` loaded via router-view on `Cases`
- fix(pages): update, refactor, fix all `CaseForm` styles to have stable behavior
- fix(comps): fix transition type in `TabbedCard`
- refactor(pages): update script lang + remove unused styles in `CaseForm`
- fix(pages): set padding on `CaseForm` actions
- refactor(pages): remove dead code from `CaseForm`
- fix(comps): fix, improve, refactor styles in `PhoneComponentButton`
- feat(pages): improve layout for PhoneComponentButtons, fix active call tabs
- feat(pages): make `PhoneSystem` page mobile friendly with map, phone actions, & form
- refactor(pages): remove unused mobile map template
- refactor(pages): remove unused styles on `PhoneSystem`
- refactor(comps): use BEM methodology for css classes on `PhoneComponentButton`
- fix(pages): open hidden caller `PhoneComponentButton` tab when caller object gets populated
- refactor(pages): BEMify css classes on `PhoneSystem`
- fix(comps): remove h-full limit on `PhoneComponentButton`
- fix(pages): set responsive styles for all `PhoneComponentButton`s on `PhoneSystem`
- fix(comps): update message area + padding for `Chat`
- feat(pages): improve `PhoneComponentButton` heights

### Current Behavior

![before](https://user-images.githubusercontent.com/46167867/194434648-f6083e45-88ff-48eb-b8af-c9e1560ff203.gif)

### New Behavior

![after](https://user-images.githubusercontent.com/46167867/194434653-333586fe-48a7-42f9-a79e-f092602612be.gif)

<!--
- This project only accepts pull requests related to open issues
- If suggesting a new feature or change, please discuss it in an issue first
- Does your pull request close any issue? If so, please provide a link to the issue.
- If your pull request references an issue, please provide a link to the issue.
-->
## Related Issue

N/A

<!--
- Why is this change required?
- What problem does it solve?
-->
<!-- ## Motivation and Context -->

<!--
- What types of changes does your code introduce?
- Put an `x` in all the boxes that apply:
-->
## Pull Request Type

Please check the type of change your PR introduces:

- [x] Bugfix
- [x] Feature
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation changes

<!--
- Go over all the following points, and put an `x` in all the boxes that apply.
- If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
## Checklist

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact of your change below. -->

<!--
- Provide additional context if necessary.
- Examples: version, OS, Browser, Other environment information, error logs, etc.
-->
<!-- ## Additional Context -->

